### PR TITLE
日記の一覧画面を実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -46,6 +46,7 @@
 
 .btn {
   --btn-noise: none;
+  font-family: var(--font-mplus);
 }
 .btn:active {
   opacity: 0.5;

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,4 +1,15 @@
 class DiariesController < ApplicationController
+  before_action :authenticate_user!
+
+  def my_diaries
+    @diaries = current_user.diaries.order(created_at: :desc)
+  end
+
+  def public_diaries
+    @diaries = Diary.is_public.includes(:user).order(created_at: :desc)
+  end
+
+
   def new
     @diary_form = DiaryForm.new(user_id: current_user.id, posted_date: Date.current)
   end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,4 +1,6 @@
 class HomesController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,6 @@
 class HomesController < ApplicationController
   before_action :authenticate_user!
-  
+
   def index
   end
 end

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,0 +1,20 @@
+<div class="card bg-white shadow-xl mb-6">
+  <div class="card-body">
+    <div class="flex space-x-8">
+      <span><%= diary.user.name %></span>
+      <span><%= diary.created_at.strftime('%Y年%m月%d日') %></span>
+    </div>
+    <ol class="list-none space-y-2">
+      <% diary.diary_contents.each_with_index do |content, i| %>
+        <li>
+          <span class="mr-2"><%= i + 1 %>.</span>
+          <%= content.body %>
+        </li>
+      <% end %>
+    </ol>
+    
+    <div class="badge badge-outline badge-primary mt-4 glass-secondary">
+      <%= diary.is_public? ? "公開" : "非公開" %>
+    </div>
+  </div>
+</div>

--- a/app/views/diaries/my_diaries.html.erb
+++ b/app/views/diaries/my_diaries.html.erb
@@ -1,6 +1,4 @@
 <div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
-  <p class="text-lg lg:2xl font-bold font-mplus">自分の日記一覧</p>
-  
   <div class="w-full mt-4 space-y-4">
     <% if @diaries.any? %>
       <%= render @diaries %>

--- a/app/views/diaries/my_diaries.html.erb
+++ b/app/views/diaries/my_diaries.html.erb
@@ -3,26 +3,7 @@
   
   <div class="w-full mt-4 space-y-4">
     <% if @diaries.any? %>
-      <% @diaries.each do |diary| %>
-        <div class="card bg-white shadow-xl">
-          <div class="card-body">
-              <%= diary.created_at.strftime('%Y年%m月%d日') %>
-            
-            <ol class="list-none space-y-2">
-              <% diary.diary_contents.each_with_index do |content, i| %>
-                <li>
-                  <span class="mr-2"><%= i + 1 %>.</span>
-                  <%= content.body %>
-                </li>
-              <% end %>
-            </ol>
-            
-            <div class="badge badge-outline badge-primary mt-4">
-              <%= diary.is_public? ? "公開" : "非公開" %>
-            </div>
-          </div>
-        </div>
-      <% end %>
+      <%= render @diaries %>
     <% else %>
       <div class="alert alert-info shadow-lg">
         <div>

--- a/app/views/diaries/my_diaries.html.erb
+++ b/app/views/diaries/my_diaries.html.erb
@@ -1,0 +1,39 @@
+<div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
+  <p class="text-lg lg:2xl font-bold font-mplus">自分の日記一覧</p>
+  
+  <div class="w-full mt-4 space-y-4">
+    <% if @diaries.any? %>
+      <% @diaries.each do |diary| %>
+        <div class="card bg-white shadow-xl">
+          <div class="card-body">
+              <%= diary.created_at.strftime('%Y年%m月%d日') %>
+            
+            <ol class="list-none space-y-2">
+              <% diary.diary_contents.each_with_index do |content, i| %>
+                <li>
+                  <span class="mr-2"><%= i + 1 %>.</span>
+                  <%= content.body %>
+                </li>
+              <% end %>
+            </ol>
+            
+            <div class="badge badge-outline badge-primary mt-4">
+              <%= diary.is_public? ? "公開" : "非公開" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="alert alert-info shadow-lg">
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+          <span>まだ日記がありません。最初の投稿をしてみましょう！</span>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  
+  <div class="mt-8 text-center">
+    <%= link_to '新しい日記を書く', new_diary_path, class: "btn btn-primary btn-lg" %>
+  </div>
+</div>

--- a/app/views/diaries/public_diaries.html.erb
+++ b/app/views/diaries/public_diaries.html.erb
@@ -1,6 +1,4 @@
 <div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
-  <p class="text-lg lg:2xl font-bold font-mplus">みんなの日記一覧</p>
-  
   <div class="w-full mt-4 space-y-4">
     <% if @diaries.any? %>
       <%= render @diaries %>

--- a/app/views/diaries/public_diaries.html.erb
+++ b/app/views/diaries/public_diaries.html.erb
@@ -1,0 +1,16 @@
+<div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
+  <p class="text-lg lg:2xl font-bold font-mplus">みんなの日記一覧</p>
+  
+  <div class="w-full mt-4 space-y-4">
+    <% if @diaries.any? %>
+      <%= render @diaries %>
+    <% else %>
+      <div class="alert alert-info shadow-lg">
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+          <span>まだ公開されている日記はありません。</span>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,15 +5,15 @@
       <span class="text-xs text-gray-500 mt-1"><%= t('.links.home')%></span>
     <% end %>
 
-    <div class="flex flex-col items-center">
-      <i class="fa-solid fa-book-open text-2xl md:text-3xl text-gray-500 hover:text-primary"></i>
+    <%= link_to my_diaries_path, class: "flex flex-col items-center" do %>
+      <i class="fa-solid fa-book-open text-2xl md:text-3xl <%= highlight_class(my_diaries_path) %>"></i>
       <span class="text-xs text-gray-500 mt-1"><%= t('.links.my_diary')%></span>
-    </div>
+    <% end %>
 
-    <div class="flex flex-col items-center">
-      <i class="fa-solid fa-users text-2xl md:text-3xl text-gray-500 hover:text-primary"></i>
+    <%= link_to public_diaries_path, class: "flex flex-col items-center" do %>
+      <i class="fa-solid fa-users text-2xl md:text-3xl <%= highlight_class(public_diaries_path) %>"></i>
       <span class="text-xs text-gray-500 mt-1"><%= t('.links.public_diaries')%></span>
-    </div>
+    <% end %>
 
     <div class="flex flex-col items-center">
       <i class="fa-solid fa-gear text-2xl md:text-3xl text-gray-500 hover:text-primary"></i>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,8 @@ Rails.application.routes.draw do
 
   resources :diaries
 
-  get 'my_diaries', to: 'diaries#my_diaries', as: :my_diaries
-  get 'public_diaries', to: 'diaries#public_diaries', as: :public_diaries
+  get "my_diaries", to: "diaries#my_diaries", as: :my_diaries
+  get "public_diaries", to: "diaries#public_diaries", as: :public_diaries
 
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,12 @@ Rails.application.routes.draw do
   get "top", to: "pages#top"
   get "home", to: "homes#index"
 
-  resources :diaries
+  resources :diaries do
+    collection do
+      get 'my_index'
+      get 'public_index'
+    end
+  end
 
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,8 @@ Rails.application.routes.draw do
 
   resources :diaries do
     collection do
-      get 'my_index'
-      get 'public_index'
+      get :my_diaries
+      get :public_diaries
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,12 +8,10 @@ Rails.application.routes.draw do
   get "top", to: "pages#top"
   get "home", to: "homes#index"
 
-  resources :diaries do
-    collection do
-      get :my_diaries
-      get :public_diaries
-    end
-  end
+  resources :diaries
+
+  get 'my_diaries', to: 'diaries#my_diaries', as: :my_diaries
+  get 'public_diaries', to: 'diaries#public_diaries', as: :public_diaries
 
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 実装内容の概要
- フッターのマイ日記を押すとログインしているユーザーが投稿した日記の一覧が表示されるようになりました。
- フッターのみんなの日記を押すと公開されている日記の一覧が表示されるようになりました。（参考：以下の画像でステータスが公開になっていないものはみんなの日記に表示されていないことが分かります）

**マイ日記**
・PC画面
[![Image from Gyazo](https://i.gyazo.com/d018610c3f24d1ea0d03f7cd24f5d8ec.png)](https://gyazo.com/d018610c3f24d1ea0d03f7cd24f5d8ec)

・スマホ画面
[![Image from Gyazo](https://i.gyazo.com/563e907fbbd168aaea373df3355d15e0.png)](https://gyazo.com/563e907fbbd168aaea373df3355d15e0)

**みんなの日記**
・PC画面
[![Image from Gyazo](https://i.gyazo.com/66d0b8e496bc9776ddbd3ae8d2e94fc7.png)](https://gyazo.com/66d0b8e496bc9776ddbd3ae8d2e94fc7)

・スマホ画面
[![Image from Gyazo](https://i.gyazo.com/777db2337757d4614b1ecae47be1bcd0.png)](https://gyazo.com/777db2337757d4614b1ecae47be1bcd0)

## 技術的な詳細
- ルーティングを`get "my_diaries", to: "diaries#my_diaries", as: :my_diaries` ` get "public_diaries", to: "diaries#public_diaries", as: :public_diaries`と個別に定義しました。URLとパスヘルパーが直感的になりました。
- 日記のカード表示部分を `app/views/diaries/_diary.html.erb` パーシャルとして切り出しました。
- `my_diaries.html.erb` と `public_diaries.html.erb` の両方でこのパーシャルを再利用しています。
- みんなの日記一覧表示では、`includes(:user)` を使ってN+1問題を回避し、パフォーマンスを向上させています。
- 日記の項目は、`DiaryContent`モデルとして別に保存しているため、パーシャルでは `diary.diary_contents` を使ってループ処理を行っています。

## 関連Issue
Colse #49 