### PR TITLE
日記の作成時、同日の日記がすでに作成されていたら編集フォームに遷移する機能を実装

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -10,18 +10,18 @@ class DiariesController < ApplicationController
     @diaries = Diary.is_public.includes(:user).order(created_at: :desc)
   end
 
-# 日記の新規作成時、同日の日記がすでに作成されていたら編集フォームに遷移
+  # 日記の新規作成時、同日の日記がすでに作成されていたら編集フォームに遷移
   def new
     posted_date = params[:posted_date].present? ? Date.parse(params[:posted_date]) : Date.current
     @diary = current_user.diaries.find_by(posted_date: posted_date)
-    
+
     if @diary.present?
       @diary_form = DiaryForm.from_diary(@diary)
     else
       @diary_form = DiaryForm.for_new_diary(current_user)
       @diary_form.posted_date = posted_date
     end
-    
+
   rescue ArgumentError
     redirect_to new_diary_path, alert: "日付の形式が正しくありません。"
   end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -10,9 +10,20 @@ class DiariesController < ApplicationController
     @diaries = Diary.is_public.includes(:user).order(created_at: :desc)
   end
 
-
+# 日記の新規作成時、同日の日記がすでに作成されていたら編集フォームに遷移
   def new
-    @diary_form = DiaryForm.for_new_diary(current_user)
+    posted_date = params[:posted_date].present? ? Date.parse(params[:posted_date]) : Date.current
+    @diary = current_user.diaries.find_by(posted_date: posted_date)
+    
+    if @diary.present?
+      @diary_form = DiaryForm.from_diary(@diary)
+    else
+      @diary_form = DiaryForm.for_new_diary(current_user)
+      @diary_form.posted_date = posted_date
+    end
+    
+  rescue ArgumentError
+    redirect_to new_diary_path, alert: "日付の形式が正しくありません。"
   end
 
   def create
@@ -39,6 +50,7 @@ class DiariesController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
 
   private
 

--- a/app/forms/diary_form.rb
+++ b/app/forms/diary_form.rb
@@ -89,7 +89,6 @@ class DiaryForm
     diary_id.present?
   end
 
-  # 空のフィールドを最低指定数まで確保
   def ensure_minimum_fields(min_count = 5)
     current_count = happiness_items.length
     if current_count < min_count
@@ -98,7 +97,6 @@ class DiaryForm
     end
   end
 
-  # ✅ 修正: 空でない項目のみを取得
   def valid_happiness_items
     happiness_items.reject(&:blank?)
   end
@@ -130,7 +128,6 @@ class DiaryForm
     )
   end
 
-  # ✅ 修正: valid_happiness_itemsを使用
   def create_diary_contents(diary)
     valid_happiness_items.each do |item|
       DiaryContent.create!(
@@ -148,7 +145,6 @@ class DiaryForm
     )
   end
 
-  # ✅ 修正: valid_happiness_itemsを使用
   def update_diary_contents(diary)
     diary.diary_contents.destroy_all
 

--- a/app/views/diaries/my_diaries.html.erb
+++ b/app/views/diaries/my_diaries.html.erb
@@ -13,6 +13,6 @@
   </div>
   
   <div class="mt-8 text-center">
-    <%= link_to '新しい日記を書く', new_diary_path, class: "btn btn-primary btn-lg" %>
+    <%= link_to '日記を書く', new_diary_path, class: "btn btn-primary btn-lg" %>
   </div>
 </div>


### PR DESCRIPTION
## 実行内容の概要
- 日記を作成する際、その日の日記がすでに存在していれば自動的に編集画面に遷移するようにしました。
そうすることでより日記らしい仕様になり、ユーザーも1日で何個の幸せを書いたかがわかりやすくなります。

[![Image from Gyazo](https://i.gyazo.com/f813069be259ab59847498828636708e.gif)](https://gyazo.com/f813069be259ab59847498828636708e)

## 技術的な詳細
- DiariesControllerのnewアクションを拡張し、日付パラメータを基に新規作成・編集のどちらのフォームを準備するかを判断するようにしました。

## 関連Issue
Close #55 