### PR TITLE
フラッシュメッセージを表示させるように設定

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -52,6 +52,10 @@
   opacity: 0.5;
 }
 
+.alert-success {
+  background-color: #81c784 !important;
+}
+
 .textarea {
   min-height: auto;
   height: 48px;

--- a/app/javascript/controllers/flash_message_controller.js
+++ b/app/javascript/controllers/flash_message_controller.js
@@ -2,16 +2,20 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["container"]
+  static values = {
+    showDelay: { type: Number, default: 10 },
+    hideDelay: { type: Number, default: 8000 }
+  }
 
   connect() {
     setTimeout(() => {
       this.show()
-    }, 10);
+    }, this.showDelayValue);
 
 
     this.timer = setTimeout(() => {
       this.hide()
-    }, 8000);
+    }, this.hideDelayValue);
   }
 
   show() {

--- a/app/javascript/controllers/flash_message_controller.js
+++ b/app/javascript/controllers/flash_message_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["container"]
+
+  connect() {
+    setTimeout(() => {
+      this.show()
+    }, 10);
+
+
+    this.timer = setTimeout(() => {
+      this.hide()
+    }, 8000);
+  }
+
+  show() {
+    this.containerTarget.classList.remove("translate-y-0", "opacity-0");
+    this.containerTarget.classList.add("translate-y-full", "opacity-100");
+    this.containerTarget.classList.remove("pointer-events-none");
+    this.containerTarget.classList.add("pointer-events-auto");
+  }
+
+  hide() {
+    clearTimeout(this.timer);
+    this.containerTarget.classList.remove("translate-y-full", "opacity-100");
+    this.containerTarget.classList.add("translate-y-0", "opacity-0");
+    this.containerTarget.classList.remove("pointer-events-auto");
+    this.containerTarget.classList.add("pointer-events-none");
+  }
+
+  remove(event) {
+    if (event.propertyName === 'transform' || event.propertyName === 'opacity') {
+        this.element.remove();
+    }
+  }
+
+  disconnect() {
+    clearTimeout(this.timer);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import DiaryController from "./diary_controller"
 application.register("diary", DiaryController)
 
+import FlashMessageController from "./flash_message_controller"
+application.register("flash-message", FlashMessageController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <% if user_signed_in? %>
       <%= render 'shared/header' %>
     <% end %>
-
+    <%= render 'shared/flash_message' %>
     <main class="min-h-screen">
       <%= yield %>
     </main>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,24 @@
+<% flash.each do |type, message| %>
+  <div class="fixed top-2 z-50 left-1/2 -translate-x-1/2 rounded-full <% if type == 'notice' %>alert-success<% elsif type == 'alert' %>alert-error<% else %>alert-info<% end %> transform transition-transform duration-500 ease-in-out pointer-events-auto"
+       data-controller="flash-message"
+       data-action="animationend->flash-message#remove"
+       data-flash-message-target="container">
+    <div class="flex items-center">
+      <% if type == 'notice'%>
+        <div role="alert" class="alert alert-success">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span class="ml-1 flex-grow"><%= message %></span>
+        </div>
+      <% elsif type == 'alert'%>
+        <div role="alert" class="alert alert-error">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span class="ml-1 flex-grow"><%= message %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
## 実装内容
- フラッシュメッセージを中央に表示
- フラッシュメッセージは、8秒後に自動で消える仕様です。

[![Image from Gyazo](https://i.gyazo.com/c50d682aaabf47bbfad65247e5e77b05.gif)](https://gyazo.com/c50d682aaabf47bbfad65247e5e77b05)


## 技術的な詳細
- `app/views/shared/_flash_message.html.erb`を作成し再利用可能にしています。
- `app/views/application.html.erb`でパーシャルを利用しています。
- *stimulus*
  - `app/javascript/controllers/flash_message_controller.js`を生成。フラッシュメッセージを上から下にスライドイン。8秒後自動で消えるようにしています。

## 関連Issue
Close #59 