### PR TITLE
日記の削除機能を実装

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,6 +1,6 @@
 class DiariesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_diary, only: %i[ edit update]
+  before_action :set_diary, only: %i[ edit update destroy ]
 
   def my_diaries
     @diaries = current_user.diaries.order(created_at: :desc)
@@ -49,6 +49,11 @@ class DiariesController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @diary.destroy
+    redirect_to my_diaries_path, notice: "日記を削除しました", status: :see_other
   end
 
 

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -5,9 +5,19 @@
         <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><path fill="#a9a2a2" d="M96 320C96 289.1 121.1 264 152 264C182.9 264 208 289.1 208 320C208 350.9 182.9 376 152 376C121.1 376 96 350.9 96 320zM264 320C264 289.1 289.1 264 320 264C350.9 264 376 289.1 376 320C376 350.9 350.9 376 320 376C289.1 376 264 350.9 264 320zM488 264C518.9 264 544 289.1 544 320C544 350.9 518.9 376 488 376C457.1 376 432 350.9 432 320C432 289.1 457.1 264 488 264z"/></svg>
         </div>
-        <ul tabindex="0" class="menu dropdown-content bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-          <li><%= link_to '編集', edit_diary_path(diary) %></li>
-          <li><%= link_to '削除', "#", data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "text-red-500" %></li>
+        <ul tabindex="0" class="menu dropdown-content bg-base-100 rounded-box z-[1] w-32 p-2 shadow">
+          <li>
+            <div class="flex items-center gap-2">
+              <i class="fa-solid fa-pen-to-square" style="color: #333333;"></i>
+              <%= link_to '編集', edit_diary_path(diary) %>
+            </div>
+          </li>
+          <li>
+            <div class="flex items-center gap-2">
+              <i class="fa-solid fa-trash-can" style="color: #ef4444;"></i>
+              <%= link_to '削除', diary_path(diary), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "text-red-500" %>
+            </div>
+          </li>
         </ul>
       </div>
     <% end %>


### PR DESCRIPTION
## 実装内容
- 日記の削除機能を実装
- 誤って日記を削除しないように、削除ボタンを押すと「本当に削除しますか？」というメッセージが表示されます。

[![Image from Gyazo](https://i.gyazo.com/52a99460b2f0d5afdff59004b741a640.gif)](https://gyazo.com/52a99460b2f0d5afdff59004b741a640)

## 技術的な詳細
- 編集・削除にアイコンをつけ、より分かりやすくしました。
- `turbo_confirm: '本当に削除しますか？'`を設定し。削除ボタンを押すと本当に削除しますか？」というメッセージが表示されます。

## 関連Issue
Close #56 