### PR TITLE
Feature/diary photos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,8 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
+gem 'ruby-vips'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
-gem 'ruby-vips'
+gem "ruby-vips"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,11 +125,22 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -156,6 +167,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -320,6 +333,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.5)
+      ffi (~> 1.12)
+      logger
     rubyzip (3.0.2)
     securerandom (0.4.1)
     selenium-webdriver (4.35.0)
@@ -392,6 +408,7 @@ DEPENDENCIES
   devise (~> 4.9)
   devise-i18n
   dotenv-rails
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
   omniauth-google-oauth2
@@ -401,6 +418,7 @@ DEPENDENCIES
   rails (~> 7.2.2, >= 7.2.2.2)
   rails-i18n
   rubocop-rails-omakase
+  ruby-vips
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -64,6 +64,6 @@ class DiariesController < ApplicationController
   end
 
   def diary_form_params
-    params.require(:diary_form).permit(:status, :posted_date, happiness_items: [], photos: []).merge(user_id: current_user.id)
+    params.require(:diary_form).permit(:status, :posted_date, happiness_items: [], photos: [], delete_photo_ids:[]).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -43,14 +43,6 @@ class DiariesController < ApplicationController
 
   def update
     @diary_form = DiaryForm.from_diary(@diary)
-
-    if params[:diary_form][:remove_photos].present?
-      params[:diary_form][:remove_photos].each do |photo_id|
-        photo_to_remove = @diary.photos.find(photo_id)
-        photo_to_remove.purge
-      end
-    end
-    
     @diary_form.assign_attributes(diary_form_params)
     if @diary_form.update(@diary)
       redirect_to home_path, notice: "日記を更新しました"

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -64,6 +64,6 @@ class DiariesController < ApplicationController
   end
 
   def diary_form_params
-    params.require(:diary_form).permit(:status, :posted_date, happiness_items: []).merge(user_id: current_user.id)
+    params.require(:diary_form).permit(:status, :posted_date, happiness_items: [], photos: []).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -43,6 +43,14 @@ class DiariesController < ApplicationController
 
   def update
     @diary_form = DiaryForm.from_diary(@diary)
+
+    if params[:diary_form][:remove_photos].present?
+      params[:diary_form][:remove_photos].each do |photo_id|
+        photo_to_remove = @diary.photos.find(photo_id)
+        photo_to_remove.purge
+      end
+    end
+    
     @diary_form.assign_attributes(diary_form_params)
     if @diary_form.update(@diary)
       redirect_to home_path, notice: "日記を更新しました"

--- a/app/forms/diary_form.rb
+++ b/app/forms/diary_form.rb
@@ -7,6 +7,7 @@ class DiaryForm
   attribute :posted_date, :date
   attribute :diary_id, :integer
   attribute :happiness_items
+  attribute :photos
 
   validates :user_id, presence: true
   validates :status, presence: true
@@ -126,6 +127,7 @@ class DiaryForm
       posted_date: posted_date,
       happiness_count: valid_happiness_items.count
     )
+    diary.photos.attach(photos) if photos.present?
   end
 
   def create_diary_contents(diary)
@@ -143,6 +145,7 @@ class DiaryForm
       posted_date: posted_date,
       happiness_count: valid_happiness_items.count
     )
+    diary.photos.attach(photos) if photos.present?
   end
 
   def update_diary_contents(diary)

--- a/app/forms/diary_form.rb
+++ b/app/forms/diary_form.rb
@@ -8,7 +8,7 @@ class DiaryForm
   attribute :diary_id, :integer
   attribute :happiness_items
   attribute :photos, default: []
-  attribute :remove_photos, default: []
+  attribute :delete_photo_ids, default: []
 
   validates :user_id, presence: true
   validates :status, presence: true
@@ -121,7 +121,7 @@ class DiaryForm
   def total_photos_count
     existing_count = existing_photos&.attached? ? existing_photos.count : 0
     new_count = photos.present? ? photos.reject(&:blank?).count : 0
-    removed_count = remove_photos.present? ? remove_photos.count : 0
+    removed_count = delete_photo_ids.present? ? delete_photo_ids.count : 0
 
     existing_count + new_count - removed_count
   end
@@ -189,7 +189,7 @@ class DiaryForm
   end
 
   def update_diary(diary)
-    remove_selected_photos(diary) if remove_photos.present?
+    delete_selected_photos(diary) if delete_photo_ids.present?
 
     diary.update!(
       status: status,
@@ -199,8 +199,8 @@ class DiaryForm
     attach_new_photos(diary) if photos.present?
   end
 
-  def remove_selected_photos(diary)
-    remove_photos.each do |photo_id|
+  def delete_selected_photos(diary)
+    delete_photo_ids.each do |photo_id|
       next if photo_id.blank?
 
       photo_to_remove = diary.photos.find_by(id: photo_id)

--- a/app/forms/diary_form.rb
+++ b/app/forms/diary_form.rb
@@ -17,6 +17,8 @@ class DiaryForm
   validate :at_least_one_happiness_present
   # 各項目の文字数制限
   validate :happiness_items_length
+  # 画像の枚数制限
+  validate :validate_photos_count
 
   def self.from_diary(diary)
     new(
@@ -120,14 +122,21 @@ class DiaryForm
     end
   end
 
+  def validate_photos_count
+    if photos.present? && photos.count > 6
+      errors.add(:photos, "は6枚以内でアップロードしてください")
+    end
+  end
+
   def create_diary
-    Diary.create!(
+    diary = Diary.create!(
       user_id: user_id,
       status: status,
       posted_date: posted_date,
       happiness_count: valid_happiness_items.count
     )
     diary.photos.attach(photos) if photos.present?
+    diary
   end
 
   def create_diary_contents(diary)

--- a/app/forms/diary_form.rb
+++ b/app/forms/diary_form.rb
@@ -122,7 +122,7 @@ class DiaryForm
     existing_count = existing_photos&.attached? ? existing_photos.count : 0
     new_count = photos.present? ? photos.reject(&:blank?).count : 0
     removed_count = remove_photos.present? ? remove_photos.count : 0
-    
+
     existing_count + new_count - removed_count
   end
 
@@ -152,15 +152,15 @@ class DiaryForm
 
   def validate_photos_format
     return unless photos.present?
-    
+
     photos.each do |photo|
       next if photo.blank? || !photo.respond_to?(:content_type)
-      
+
       unless photo.content_type.in?(%w[image/jpeg image/png image/gif])
         errors.add(:photos, "はJPEG、PNG、GIF形式でアップロードしてください")
         break
       end
-      
+
       if photo.size > 5.megabytes
         errors.add(:photos, "は1枚あたり5MB以内でアップロードしてください")
         break
@@ -202,7 +202,7 @@ class DiaryForm
   def remove_selected_photos(diary)
     remove_photos.each do |photo_id|
       next if photo_id.blank?
-      
+
       photo_to_remove = diary.photos.find_by(id: photo_id)
       photo_to_remove&.purge
     end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("flash-message", FlashMessageController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import PhotoPreviewController from "./photo_preview_controller"
+application.register("photo-preview", PhotoPreviewController)
+
 import StatusSelectorController from "./status_selector_controller"
 application.register("status-selector", StatusSelectorController)
 

--- a/app/javascript/controllers/photo_preview_controller.js
+++ b/app/javascript/controllers/photo_preview_controller.js
@@ -1,0 +1,156 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "preview", "existingPhoto"]
+  
+  connect() {
+    this.selectedFiles = []
+    this.setupExistingPhotos()
+  }
+
+  // 既存写真に削除ボタンを追加
+  setupExistingPhotos() {
+    this.existingPhotoTargets.forEach((photoDiv, index) => {
+      // 既に削除ボタンがある場合はスキップ
+      if (photoDiv.querySelector('.delete-existing-btn')) return
+      
+      const deleteButton = document.createElement('button')
+      deleteButton.type = 'button'
+      deleteButton.className = 'absolute top-2 right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold shadow-lg delete-existing-btn'
+      deleteButton.innerHTML = '×'
+      deleteButton.dataset.action = 'click->photo-preview#removeExisting'
+      // 🔥 ボタンにはphoto-idを付けない！親要素から取得する
+      deleteButton.dataset.photoId = photoDiv.dataset.photoId
+      
+      photoDiv.appendChild(deleteButton)
+    })
+  }
+
+  // 🎯 既存画像の削除（完全修正版）
+  removeExisting(event) {
+    const button = event.currentTarget
+    const photoId = button.dataset.photoId
+    
+    // 🔥 削除ボタンの親要素（画像のdiv）を直接取得
+    const photoDiv = button.parentElement
+    
+    // 削除用の隠しフィールドを追加
+    this.addDeleteField(photoId)
+    
+    // 🔥 画面から完全に削除（アニメーション付き）
+    this.animateRemove(photoDiv)
+  }
+
+  // 新規ファイルのプレビュー
+  preview() {
+    const newPhotoContainer = this.previewTarget.querySelector('.new-photos')
+    if (newPhotoContainer) {
+      newPhotoContainer.innerHTML = ''
+    } else {
+      const container = document.createElement('div')
+      container.className = 'new-photos contents'
+      this.previewTarget.appendChild(container)
+    }
+    
+    this.selectedFiles = []
+    const files = Array.from(this.inputTarget.files)
+    
+    files.forEach((file, index) => {
+      if (file.type.startsWith('image/')) {
+        this.selectedFiles.push(file)
+        this.createNewPreview(file, index)
+      }
+    })
+  }
+
+  // 新規画像のプレビュー作成
+  createNewPreview(file, index) {
+    const reader = new FileReader()
+    
+    reader.onload = (e) => {
+      const div = document.createElement('div')
+      // 🎯 レスポンシブ対応の高さ設定
+      div.className = 'relative w-full h-32 sm:h-40 md:h-48 lg:h-56'
+      div.innerHTML = `
+        <img src="${e.target.result}" 
+            class="w-full h-32 sm:h-40 md:h-48 lg:h-56 object-cover rounded-lg shadow-sm hover:shadow-md transition-all duration-200">
+        <button type="button" 
+                class="absolute top-1 right-1 sm:top-2 sm:right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-5 h-5 sm:w-6 sm:h-6 flex items-center justify-center text-xs sm:text-sm font-bold shadow-lg transition-all duration-200 z-10"
+                data-action="click->photo-preview#removeNew"
+                data-index="${index}">
+          ×
+        </button>
+      `
+      
+      const newPhotoContainer = this.previewTarget.querySelector('.new-photos')
+      newPhotoContainer.appendChild(div)
+    }
+    
+    reader.readAsDataURL(file)
+  }
+
+  // 新規画像の削除
+  removeNew(event) {
+    const index = parseInt(event.currentTarget.dataset.index)
+    
+    // ファイル配列から削除
+    this.selectedFiles.splice(index, 1)
+    
+    // DataTransferで新しいFileListを作成
+    const dt = new DataTransfer()
+    this.selectedFiles.forEach(file => dt.items.add(file))
+    this.inputTarget.files = dt.files
+    
+    // プレビューを再描画
+    this.preview()
+  }
+
+  // 🎪 アニメーション付きで要素を削除
+  animateRemove(element) {
+    console.log('削除開始:', element)
+    console.log('要素のタグ名:', element.tagName)
+    console.log('要素の内容（最初の100文字）:', element.innerHTML.substring(0, 100))
+    
+    // フェードアウトアニメーション
+    element.style.transition = 'all 0.3s ease-out'
+    element.style.transform = 'scale(0.8)'
+    element.style.opacity = '0'
+    
+    // アニメーション完了後に要素を削除
+    setTimeout(() => {
+      console.log('要素を削除:', element)
+      element.remove() // 🔥 ここで画像要素全体を完全に削除
+      
+      // グリッドが空になった場合の処理
+      this.checkEmptyGrid()
+    }, 300)
+  }
+
+  // グリッドが空かどうかをチェック
+  checkEmptyGrid() {
+    const hasExistingPhotos = this.previewTarget.querySelectorAll('[data-photo-id]').length > 0
+    const hasNewPhotos = this.previewTarget.querySelector('.new-photos')?.children.length > 0
+    
+    // 画像が一つもない場合はグリッドを非表示
+    if (!hasExistingPhotos && !hasNewPhotos) {
+      this.previewTarget.style.display = 'none'
+    } else {
+      this.previewTarget.style.display = 'grid'
+    }
+  }
+
+  // 削除用の隠しフィールドを追加
+  addDeleteField(photoId) {
+    // 既に削除フィールドがある場合はスキップ
+    if (this.element.querySelector(`input[name="diary_form[delete_photo_ids][]"][value="${photoId}"]`)) {
+      return
+    }
+    
+    const hiddenField = document.createElement('input')
+    hiddenField.type = 'hidden'
+    hiddenField.name = 'diary_form[delete_photo_ids][]'
+    hiddenField.value = photoId
+    
+    this.element.appendChild(hiddenField)
+ }
+}

--- a/app/javascript/controllers/photo_preview_controller.js
+++ b/app/javascript/controllers/photo_preview_controller.js
@@ -19,25 +19,19 @@ export default class extends Controller {
       deleteButton.className = 'absolute top-2 right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold shadow-lg delete-existing-btn'
       deleteButton.innerHTML = '×'
       deleteButton.dataset.action = 'click->photo-preview#removeExisting'
-      // 🔥 ボタンにはphoto-idを付けない！親要素から取得する
       deleteButton.dataset.photoId = photoDiv.dataset.photoId
       
       photoDiv.appendChild(deleteButton)
     })
   }
 
-  // 🎯 既存画像の削除（完全修正版）
+  // 既存画像の削除
   removeExisting(event) {
     const button = event.currentTarget
     const photoId = button.dataset.photoId
-    
-    // 🔥 削除ボタンの親要素（画像のdiv）を直接取得
     const photoDiv = button.parentElement
     
-    // 削除用の隠しフィールドを追加
     this.addDeleteField(photoId)
-    
-    // 🔥 画面から完全に削除（アニメーション付き）
     this.animateRemove(photoDiv)
   }
 
@@ -69,7 +63,6 @@ export default class extends Controller {
     
     reader.onload = (e) => {
       const div = document.createElement('div')
-      // 🎯 レスポンシブ対応の高さ設定
       div.className = 'relative w-full h-32 sm:h-40 md:h-48 lg:h-56'
       div.innerHTML = `
         <img src="${e.target.result}" 
@@ -107,10 +100,6 @@ export default class extends Controller {
 
   // 🎪 アニメーション付きで要素を削除
   animateRemove(element) {
-    console.log('削除開始:', element)
-    console.log('要素のタグ名:', element.tagName)
-    console.log('要素の内容（最初の100文字）:', element.innerHTML.substring(0, 100))
-    
     // フェードアウトアニメーション
     element.style.transition = 'all 0.3s ease-out'
     element.style.transform = 'scale(0.8)'
@@ -118,8 +107,7 @@ export default class extends Controller {
     
     // アニメーション完了後に要素を削除
     setTimeout(() => {
-      console.log('要素を削除:', element)
-      element.remove() // 🔥 ここで画像要素全体を完全に削除
+      element.remove()
       
       // グリッドが空になった場合の処理
       this.checkEmptyGrid()

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -3,12 +3,11 @@ class Diary < ApplicationRecord
   has_many :diary_contents, dependent: :destroy
 
   has_many_attached :photos do |attachable|
-    attachable.variant :thumb, resize_to_limit: [200, 200]
+    attachable.variant :thumb, resize_to_limit: [ 200, 200 ]
   end
 
   validates :happiness_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :posted_date, presence: true
 
   enum :status, { is_public: 0, is_private: 1 }
-
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -11,17 +11,4 @@ class Diary < ApplicationRecord
 
   enum :status, { is_public: 0, is_private: 1 }
 
-  private
-
-  def validate_photos_format
-    if photos.attached? && !photos.content_type.in?(%w[image/jpeg image/png image/gif])
-      errors.add(:image, "：ファイル形式が、JPEG, PNG, GIF以外になってます。ファイル形式をご確認ください")
-    end
-  end
-
-  def photos_size
-    if photos.attached? && photos.byte_size > 5.megabytes
-      errors.add(:photos, "のファイルサイズは5MB以内にしてください")
-    end
-  end
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,11 +1,27 @@
 class Diary < ApplicationRecord
   belongs_to :user
   has_many :diary_contents, dependent: :destroy
-  
-  has_many_attached :photos
+
+  has_many_attached :photos do |attachable|
+    attachable.variant :thumb, resize_to_limit: [200, 200]
+  end
 
   validates :happiness_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :posted_date, presence: true
 
   enum :status, { is_public: 0, is_private: 1 }
+
+  private
+
+  def validate_photos_format
+    if photos.attached? && !photos.content_type.in?(%w[image/jpeg image/png image/gif])
+      errors.add(:image, "：ファイル形式が、JPEG, PNG, GIF以外になってます。ファイル形式をご確認ください")
+    end
+  end
+
+  def photos_size
+    if photos.attached? && photos.byte_size > 5.megabytes
+      errors.add(:photos, "のファイルサイズは5MB以内にしてください")
+    end
+  end
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,6 +1,8 @@
 class Diary < ApplicationRecord
   belongs_to :user
   has_many :diary_contents, dependent: :destroy
+  
+  has_many_attached :photos
 
   validates :happiness_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :posted_date, presence: true

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -35,6 +35,16 @@
       <% end %>
     </ol>
     
+    <% if diary.photos.attached? %>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+        <% diary.photos.each do |photo| %>
+          <div class="relative w-full aspect-square">
+            <%= image_tag photo, class: "w-full h-full object-cover rounded-lg shadow-sm" %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
     <div class="badge badge-outline badge-primary mt-4 glass-secondary">
       <%= diary.is_public? ? "公開" : "非公開" %>
     </div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -36,10 +36,10 @@
     </ol>
     
     <% if diary.photos.attached? %>
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
         <% diary.photos.each do |photo| %>
-          <div class="relative w-full aspect-square">
-            <%= image_tag photo, class: "w-full h-full object-cover rounded-lg shadow-sm" %>
+          <div class="relative w-full">
+            <%= image_tag photo.variant(:thumb), class: "w-full h-full object-contain rounded-lg shadow-sm" %>
           </div>
         <% end %>
       </div>

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -72,18 +72,36 @@
 
     <div class="flex flex-col items-center mt-4">
       <!-- 写真追加 -->
-      <% if @diary_form.existing_photos&.attached? %>
-        <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
-          <% @diary_form.existing_photos.each do |photo| %>
-            <div class="relative w-full">
-              <%= image_tag photo.variant(:thumb), class: "w-full h-full object-contain rounded-lg shadow-sm" %>
-            </div>
+      <div data-controller="photo-preview">
+        <div data-photo-preview-target="preview" 
+            class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
+          
+          <!-- 既存の画像 -->
+          <% if @diary_form.existing_photos&.attached? %>
+            <% @diary_form.existing_photos.each do |photo| %>
+              <div class="relative w-full h-32 sm:h-40 md:h-48 lg:h-56"
+                  data-photo-preview-target="existingPhoto"
+                  data-photo-id="<%= photo.id %>">
+                <%= image_tag photo.variant(:thumb),
+                              class: "w-full h-32 sm:h-40 md:h-48 lg:h-56 object-cover rounded-lg shadow-sm transition-all duration-200" %>
+                <!-- 削除ボタンはJavaScriptで追加 -->
+              </div>
+            <% end %>
           <% end %>
+
         </div>
-      <% end %>
-      
-      <%= f.file_field :photos, class: "file-input file-input-secondary", multiple: true %>
-      
+
+      <div class="w-full flex justify-center mt-4">
+        <%= f.file_field :photos, 
+                        class: "file-input file-input-secondary", 
+                        multiple: true,
+                        accept: "image/*",
+                        data: {
+                          photo_preview_target: "input",
+                          action: "change->photo-preview#preview"
+                        } %>
+      </div>
+    </div>
       <!-- 公開・非公開ボタン -->
       <div data-controller="status-selector" class="flex items-center space-x-4 mt-8">
         <div data-action="click->status-selector#select" data-value="is_public">

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -72,6 +72,16 @@
 
     <div class="flex flex-col items-center mt-4">
       <!-- 写真追加 -->
+      <% if @diary.photos.attached? %>
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
+          <% @diary.photos.each do |photo| %>
+            <div class="relative w-full">
+              <%= image_tag photo.variant(:thumb), class: "w-full h-full object-contain rounded-lg shadow-sm" %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+      
       <%= f.file_field :photos, class: "file-input file-input-secondary", multiple: true %>
       
       <!-- 公開・非公開ボタン -->

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -72,9 +72,9 @@
 
     <div class="flex flex-col items-center mt-4">
       <!-- 写真追加 -->
-      <% if @diary.photos.attached? %>
+      <% if @diary_form.existing_photos&.attached? %>
         <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
-          <% @diary.photos.each do |photo| %>
+          <% @diary_form.existing_photos.each do |photo| %>
             <div class="relative w-full">
               <%= image_tag photo.variant(:thumb), class: "w-full h-full object-contain rounded-lg shadow-sm" %>
             </div>

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -70,8 +70,11 @@
       </template>
     </div>
 
-    <!-- 公開・非公開ボタン -->
     <div class="flex flex-col items-center mt-4">
+      <!-- 写真追加 -->
+      <%= f.file_field :photos, class: "file-input file-input-secondary", multiple: true %>
+      
+      <!-- 公開・非公開ボタン -->
       <div data-controller="status-selector" class="flex items-center space-x-4 mt-8">
         <div data-action="click->status-selector#select" data-value="is_public">
           <button type="button" data-status-selector-target="button" class="btn btn-outline <%= @diary_form.status == 'is_public' ? 'btn-active btn-secondary' : '' %>">公開</button>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
       <%= render 'shared/header' %>
     <% end %>
     <%= render 'shared/flash_message' %>
-    <main class="min-h-screen">
+    <main class="min-h-screen pb-20">
       <%= yield %>
     </main>
     

--- a/config/locales/activerecord/ja.ym
+++ b/config/locales/activerecord/ja.ym
@@ -1,4 +1,0 @@
-ja:
-  activerecord:
-    models:
-    attributes:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,7 @@
+ja:
+  activemodel:
+    attributes:
+      diary_form:
+        photos: 写真
+  activerecord:
+    attributes:

--- a/db/migrate/20250906112358_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250906112358_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_04_030046) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_06_112358) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "diaries", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -49,6 +77,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_04_030046) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "diaries", "users"
   add_foreign_key "diary_contents", "diaries"
 end


### PR DESCRIPTION
## 実装内容の概要
- 日記の投稿に写真を付けることが可能になりました。
  - 画像は最大6枚までアップロードすることが可能です。
  - 画像は1枚あたり5MBまでです。
  - 画像はJPEG、PNG、GIF形式のみアップロードすることが可能です。
  - 画像は200x200にリサイズしています。
- 日記の投稿・編集フォームで写真を追加した際にプレビューが表示され、×ボタンで削除可能です。
- 日記の投稿ボタンがフッターに隠れている問題を修正しました。
- レスポンシブ対応済みです。

PC画面
- 画像の削除と追加
[![Image from Gyazo](https://i.gyazo.com/7f1fb364c55b996c0c9ac9a0de841662.gif)](https://gyazo.com/7f1fb364c55b996c0c9ac9a0de841662)

- 編集画面（プレビュー機能）
[![Image from Gyazo](https://i.gyazo.com/089ecdea5f19ba81dfec8d25fca13b4e.gif)](https://gyazo.com/089ecdea5f19ba81dfec8d25fca13b4e)

- マイ日記画面
[![Image from Gyazo](https://i.gyazo.com/8fdec043e08335dcac481c8b88058914.png)](https://gyazo.com/8fdec043e08335dcac481c8b88058914)

スマホ画面
- 編集画面
[![Image from Gyazo](https://i.gyazo.com/85b896cb88433d269370b72da431b6f4.gif)](https://gyazo.com/85b896cb88433d269370b72da431b6f4)

- マイ日記画面
[![Image from Gyazo](https://i.gyazo.com/4a1acf15f1be5b0abf98a57083f7e70b.png)](https://gyazo.com/4a1acf15f1be5b0abf98a57083f7e70b)

## 技術的な詳細
- **ActiveStorage**
  - 画像の保存と管理はActiveStorageを利用し、実装しています。
  - Diaryモデルに`has_many_attached :photos`を定義。バリデーションはDiaryFormに集約しています。
 
- **Stimulus**
  - `photo-preview_controller.js`を作成し、フォーム画面の画像の操作を実装しています。
  - `views/diary/_form.html.erb`内の<!-- 写真追加 -->のコメント以下のコードとStimulusは紐づいています。
  - プレビュー機能は既存の画像・新たに追加した画像のどちらにも対応しており、編集画面で削除することが可能です。

## 関連Issue
Close #38 