### PR TITLE
日記の検索機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,4 +70,4 @@ gem "rails-i18n"
 
 gem "aws-sdk-s3", require: false
 
-gem 'ransack'
+gem "ransack"

--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ gem "omniauth-rails_csrf_protection"
 gem "rails-i18n"
 
 gem "aws-sdk-s3", require: false
+
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -438,6 +442,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.2)
   rails-i18n
+  ransack
   rubocop-rails-omakase
   ruby-vips
   selenium-webdriver

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -3,11 +3,13 @@ class DiariesController < ApplicationController
   before_action :set_diary, only: %i[ edit update destroy ]
 
   def my_diaries
-    @diaries = current_user.diaries.order(created_at: :desc)
+    @q = current_user.diaries.ransack(params[:q])
+    @diaries = @q.result(distinct: true).order(created_at: :desc)
   end
 
   def public_diaries
-    @diaries = Diary.is_public.includes(:user).order(created_at: :desc)
+    @q = Diary.is_public.ransack(params[:q])
+    @diaries = @q.result(distinct: true).includes(:user).order(created_at: :desc)
   end
 
   # 日記の新規作成時、同日の日記がすでに作成されていたら編集フォームに遷移

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -12,4 +12,13 @@ class Diary < ApplicationRecord
   validates :posted_date, presence: true
 
   enum :status, { is_public: 0, is_private: 1 }
+
+
+  def self.ransackable_attributes(auth_object = nil)
+    []
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[diary_contents tags]
+  end
 end

--- a/app/models/diary_content.rb
+++ b/app/models/diary_content.rb
@@ -2,4 +2,12 @@ class DiaryContent < ApplicationRecord
   belongs_to :diary
 
   validates :body, presence: true, length: { maximum: 1000 }
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[body]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,4 +3,12 @@ class Tag < ApplicationRecord
   has_many :diaries, through: :diary_tags
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 20 }
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -51,7 +51,7 @@
 
     <div class="flex flex-wrap space-x-2">
       <% diary.tags.each do |tag| %>
-        <div class="badge badge-outline badge-accent">
+        <div class="badge badge-outline badge-accent mt-2">
           <%= tag.name %>
         </div>
       <% end %>

--- a/app/views/diaries/_search.html.erb
+++ b/app/views/diaries/_search.html.erb
@@ -1,0 +1,4 @@
+<%= search_form_for @q, url: url, html: { class: "flex flex-col md:flex-row items-center w-full gap-2" } do |f| %>
+  <%= f.search_field :diary_contents_body_or_tags_name_cont, placeholder: "検索ワード", class: "input input-bordered flex-grow w-full" %>
+  <%= f.submit "検索", class: "btn" %>
+<% end %>

--- a/app/views/diaries/my_diaries.html.erb
+++ b/app/views/diaries/my_diaries.html.erb
@@ -1,5 +1,6 @@
 <div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
   <div class="w-full mt-4 space-y-4">
+    <%= render "search", url: my_diaries_path %>
     <% if @diaries.any? %>
       <%= render @diaries %>
     <% else %>

--- a/app/views/diaries/public_diaries.html.erb
+++ b/app/views/diaries/public_diaries.html.erb
@@ -1,5 +1,6 @@
 <div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
   <div class="w-full mt-4 space-y-4">
+    <%= render "search", url: public_diaries_path %>
     <% if @diaries.any? %>
       <%= render @diaries %>
     <% else %>


### PR DESCRIPTION
## 実装内容の概要
-  日記のタグと本文の内容でキーワード検索できる機能を実装しました。
-  マイ日記とみんなの日記の両方で検索が可能です。
-  レスポンシブ対応済みです

PC画面（検索実行画面）
[![Image from Gyazo](https://i.gyazo.com/b8f762680d74b8836fdf0cbf9c2e09c1.gif)](https://gyazo.com/b8f762680d74b8836fdf0cbf9c2e09c1)

スマホ画面（マイ日記）
[![Image from Gyazo](https://i.gyazo.com/c0012e204ee746eeabfdf47fc64072c3.png)](https://gyazo.com/c0012e204ee746eeabfdf47fc64072c3)


## 技術的な詳細
- **Ransack**
  - `gem "ransack"`をインストールしました。
  - Ransackのバージョン4.0.0以降、「明示的な許可リスト」が必須となりました。そのため、`Diary` `DiaryContent` `Tag`の各モデルに`ransackable_attributes`と`ransackable_associations`を定義しています。
  - 検索対象としない`Diary`モデル自身のカラムは、`ransackable_attributesは`[]`。関連付けを持たないモデルの`ransackable_associations`は`[]`（空の配列）と設定しました。これにより、不要なカラムや関連付けが検索対象になることを防いでいます。（この設定をしないとエラーがでます。）
 
- **UI**
  - 検索フォームを`views/diaries/_search.html.erb`にパーシャルとして切り出し、再利用性を高めました。
  - `views/diaries/my_diaries.html.erb` `views/diaries/public_diaries.html.erb`の両方でこのパーシャルを利用しています。
 
## 確認事項
- [x] タグの一部を検索し、想定通りの検索結果になるか
- [x] 本文の一部を検索し、想定通りの検索結果になるか

## 関連Issue
Close #17 