### PR TITLE
オートコンプリート機能を実装

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -58,6 +58,12 @@ class DiariesController < ApplicationController
     redirect_to my_diaries_path, notice: "日記を削除しました", status: :see_other
   end
 
+  def autocomplete
+    @tags = Tag.where("name like ?", "%#{params[:q]}%").limit(10)
+    respond_to do |format|
+      format.js
+    end
+  end
 
   private
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,9 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
 
 const application = Application.start()
+
+application.register('autocomplete', Autocomplete)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/views/diaries/_search.html.erb
+++ b/app/views/diaries/_search.html.erb
@@ -1,4 +1,10 @@
 <%= search_form_for @q, url: url, html: { class: "flex flex-col md:flex-row items-center w-full gap-2" } do |f| %>
-  <%= f.search_field :diary_contents_body_or_tags_name_cont, placeholder: "検索ワード", class: "input input-bordered flex-grow w-full" %>
+  <div data-controller="autocomplete" data-autocomplete-url-value="<%= autocomplete_diaries_path %>" role="combobox" class="w-full relative">
+    <%= f.search_field :diary_contents_body_or_tags_name_cont,
+                       placeholder: "検索ワード",
+                       class: "input input-bordered w-full",
+                       data: { autocomplete_target: "input" } %>
+    <ul class="absolute w-full mt-2 z-10 shadow bg-base-100 rounded-md" data-autocomplete-target="results"></ul>
+  </div>
   <%= f.submit "検索", class: "btn" %>
 <% end %>

--- a/app/views/diaries/autocomplete.html.erb
+++ b/app/views/diaries/autocomplete.html.erb
@@ -1,0 +1,9 @@
+<% @tags.each do |tag| %>
+<li class="w-full flex items-center py-2 px-4 rounded-md text-sm text-gray-800 hover:bg-gray-100 overflow-hidden cursor-pointer"
+    role="option"
+    data-autocomplete-value="<%= tag.name %>"
+    data-autocomplete-label="<%= tag.name %>">
+    <span class="mr-2 text-xs">#</span>
+    <span><%= tag.name %></span>
+</li>
+<% end %>

--- a/app/views/diaries/my_diaries.html.erb
+++ b/app/views/diaries/my_diaries.html.erb
@@ -1,6 +1,7 @@
 <div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
-  <div class="w-full mt-4 space-y-4">
-    <%= render "search", url: my_diaries_path %>
+  <%= render "search", url: my_diaries_path %>
+  
+  <div class="w-full mt-8 space-y-4">
     <% if @diaries.any? %>
       <%= render @diaries %>
     <% else %>

--- a/app/views/diaries/public_diaries.html.erb
+++ b/app/views/diaries/public_diaries.html.erb
@@ -1,6 +1,7 @@
 <div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
-  <div class="w-full mt-4 space-y-4">
-    <%= render "search", url: public_diaries_path %>
+  <%= render "search", url: public_diaries_path %>
+  
+  <div class="w-full mt-8 space-y-4">
     <% if @diaries.any? %>
       <%= render @diaries %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
 
   resources :diaries do
     collection do
-    get :autocomplete
+      get :autocomplete
+    end
   end
 
   get "my_diaries", to: "diaries#my_diaries", as: :my_diaries

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,10 @@ Rails.application.routes.draw do
   get "top", to: "pages#top"
   get "home", to: "homes#index"
 
-  resources :diaries
+  resources :diaries do
+    collection do
+    get :autocomplete
+  end
 
   get "my_diaries", to: "diaries#my_diaries", as: :my_diaries
   get "public_diaries", to: "diaries#public_diaries", as: :public_diaries

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@hotwired/turbo-rails": "^8.0.16",
         "@tailwindcss/cli": "^4.1.12",
         "daisyui": "^5.0.54",
+        "stimulus-autocomplete": "^3.1.0",
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
@@ -618,6 +619,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stimulus-autocomplete": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz",
+      "integrity": "sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@hotwired/stimulus": "^3.0.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@hotwired/turbo-rails": "^8.0.16",
     "@tailwindcss/cli": "^4.1.12",
     "daisyui": "^5.0.54",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^4.1.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz"
   integrity sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==
 
-"@hotwired/stimulus@^3.2.2":
+"@hotwired/stimulus@^3.0.0", "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
   resolved "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz"
   integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
@@ -347,6 +347,11 @@ source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
 
 tailwindcss@^4.1.12, tailwindcss@4.1.12:
   version "4.1.12"


### PR DESCRIPTION
## 実装内容の概要
- 検索欄に文字を入力すると関連するワードがでるオートコンプリート機能を実装しました。
- タグのみ対応しております。（引き続き、日記本文も検索が可能です）
- オートコンプリート機能は最大10個まで表示されます。
- マイ日記・みんなの日記どちらも対応しています。

PC画面（検索画面）
[![Image from Gyazo](https://i.gyazo.com/df269a2e7e3194deae0cc8404af7fea0.gif)](https://gyazo.com/df269a2e7e3194deae0cc8404af7fea0)

## 技術的な詳細
- **stimulus-autocomplete**
  - `npm`で`stimulus-autocomplete`をインストールしました。Rails 7の標準である`importmap`ではなく、既存のプロジェクト構成に合わせて`npm`を選択しました。 
  - `app/javascript/controllers/application.js`にstimulus-autocompleteの設定を追加しました。
- **UI** 
  - `views/diaries/_search.html.erb`の既存の記述にオートコンプリート機能に必要な記述を追加しました。
  - `views/diaries/autocomplete.html.erb`はオートコンプリート機能の候補表示のviewになります。
    - オートコンプリート機能はタグのみの実装なのでわかりやすくハッシュタグ（#）を付けました

## 確認事項
- [x] 入力したキーワードに対して、関連するタグの候補が表示されるかどうか
- [x] 引き続き日記本文も検索が可能かどうか
- [x] 関連したワードがないときはなにも表示されないかどうか


## 関連Issue
Close #18 