### PR TITLE
設定モーダルを実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
-import "matter-js"
-import "./happiness-jar.js"
+

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,9 @@ application.register("happiness-jar", HappinessJarController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
 import PhotoPreviewController from "./photo_preview_controller"
 application.register("photo-preview", PhotoPreviewController)
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal"]
+
+  open() {
+    this.modalTarget.showModal()
+  }
+
+  close() {
+    this.modalTarget.close()
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.modalTarget) {
+      this.close()
+    }
+  }
+}

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,9 +15,13 @@
       <span class="text-xs text-gray-500 mt-1"><%= t('.links.public_diaries')%></span>
     <% end %>
 
-    <div class="flex flex-col items-center">
-      <i class="fa-solid fa-gear text-2xl md:text-3xl text-gray-500 hover:text-primary"></i>
-      <span class="text-xs text-gray-500 mt-1"><%= t('.links.settings')%></span>
+    <div data-controller="modal">
+      <button data-action="click->modal#open" class="flex flex-col items-center">
+        <i class="fa-solid fa-gear text-2xl md:text-3xl text-gray-500 hover:text-primary"></i>
+        <span class="text-xs text-gray-500 mt-1"><%= t('.links.settings')%></span>
+      </button>
+
+      <%= render "shared/settings_modal" %>
     </div>
   </div>
 </footer>

--- a/app/views/shared/_settings_modal.html.erb
+++ b/app/views/shared/_settings_modal.html.erb
@@ -1,0 +1,18 @@
+<dialog id="settingsModal"
+        data-modal-target="modal"
+        data-action="click->modal#closeOnBackdrop"
+        class="modal modal-bottom w-full md:max-w-lg lg:max-w-xl mx-auto">
+  <div class="modal-box rounded-t-2xl p-4 bg-base-100 max-h-[90vh] overflow-auto">
+    <div class="flex justify-between items-center mb-4">
+      <h3 class="font-bold text-lg">設定</h3>
+      <button class="btn btn-sm btn-circle btn-ghost"
+              data-action="click->modal#close">✕</button>
+    </div>
+
+    <ul class="space-y-2">
+      <li><%= link_to "プロフィール編集", "#", class: "btn btn-outline w-full" %></li>
+      <li><%= link_to "通知設定", "#", class: "btn btn-outline w-full" %></li>
+      <li><%= link_to "ログアウト", "#", data: { turbo_method: :delete }, class: "btn btn-error w-full" %></li>
+    </ul>
+  </div>
+</dialog>

--- a/app/views/shared/_settings_modal.html.erb
+++ b/app/views/shared/_settings_modal.html.erb
@@ -1,15 +1,15 @@
 <dialog id="settingsModal"
         data-modal-target="modal"
         data-action="click->modal#closeOnBackdrop"
-        class="modal modal-bottom w-full md:max-w-lg lg:max-w-xl mx-auto">
-  <div class="modal-box rounded-t-2xl p-4 bg-base-100 max-h-[90vh] overflow-auto">
+        class="modal modal-bottom md:modal-middle">
+  <div class="modal-box rounded-t-2xl md:rounded-2xl p-4 bg-base-100 max-h-[90vh] overflow-auto">
     <div class="flex justify-between items-center mb-4">
       <h3 class="font-bold text-lg">設定</h3>
       <button class="btn btn-sm btn-circle btn-ghost"
               data-action="click->modal#close">✕</button>
     </div>
 
-    <ul class="space-y-2">
+    <ul class="space-y-4">
       <li><%= link_to "プロフィール編集", "#", class: "btn btn-outline w-full" %></li>
       <li><%= link_to "通知設定", "#", class: "btn btn-outline w-full" %></li>
       <li><%= link_to "ログアウト", "#", data: { turbo_method: :delete }, class: "btn btn-error w-full" %></li>


### PR DESCRIPTION
## 実装内容の概要
- フッター部分の設定を押すと、モーダルが表示されるようになりました。
- 内容は以下になります。（現状各ページ未実装の為、以下の内容を押してもページ遷移はしません）
  - プロフィール編集
  - 通知設定
  - ログアウト
-  PC画面では中央に、スマホ画面では、下にモーダルを表示しています。

PC画面
[![Image from Gyazo](https://i.gyazo.com/e4531908d1f80d63b164f83e7884c2ec.gif)](https://gyazo.com/e4531908d1f80d63b164f83e7884c2ec)

スマホ画面
[![Image from Gyazo](https://i.gyazo.com/860799a39160f8e026b2e0df18a884d1.gif)](https://gyazo.com/860799a39160f8e026b2e0df18a884d1)

## 技術的な詳細
- **UI**
  - このアプリはスマホでの利用が多くなると考えているので、設定はページ遷移ではなく、よりスマホアプリライクなモーダルを採用しました。
  - PC画面ではモーダルが下に表示されることが馴染みが少ないため、中央に表示しました。
- フッターとモーダルのの役割を分離するため、`views/shared/_setting_modal.html.erb`を作成しモーダルの内容を記述しています。
- `app/javascript/controllers/modal_controller.js`を作成し、モーダルの制御を行っています。

## 確認事項
- [x] フッターの設定アイコンを押すと、モーダルが表示されること
- [x] PC画面ではモーダルは中央に表示されること
- [x] スマホ画面ではモーダルは下に表示されること
- [x] モーダル画面以外を押すことでモーダルが消えること 

## 関連Issue
Close #72 