### PR TITLE
ユーザーのログアウト・アカウント削除機能を実装

### DIFF
--- a/app/views/shared/_settings_modal.html.erb
+++ b/app/views/shared/_settings_modal.html.erb
@@ -12,7 +12,7 @@
     <ul class="space-y-4">
       <li><%= link_to "プロフィール", user_path(current_user), class: "btn btn-outline w-full" %></li>
       <li><%= link_to "通知設定", "#", class: "btn btn-outline w-full" %></li>
-      <li><%= link_to "ログアウト", "#", data: { turbo_method: :delete }, class: "btn btn-error w-full" %></li>
+      <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-error w-full" %></li>
     </ul>
   </div>
 </dialog>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,30 @@
 
     <div class="w-full mt-8 flex justify-center">
     <% if current_user == @user %>
-        <%= link_to "編集", edit_user_registration_path, class: "btn btn-primary" %>
+        <%= link_to "編集", edit_user_registration_path, class: "btn btn-primary px-10" %>
     <% end %>
     </div>
+
+    <div class="divider mt-16"></div>
+
+    <div class="mt-4 space-y-4">
+      <div class="flex justify-center">
+        <%= link_to 'アカウントを削除', user_registration_path,
+            data: { turbo_method: :delete, turbo_confirm: '本当にアカウントを削除してもよろしいですか？' },
+            class: "btn btn-warning w-40" %>
+      </div>
+
+      <div class="flex items-start gap-2 text-warning max-w-lg mx-auto">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 
+                  1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 
+                  0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <p class="text-sm">
+          アカウントを削除すると、すべてのデータが完全に削除され、復元することはできません。
+        </p>
+      </div>
+    </div>
+
 </div>


### PR DESCRIPTION
## 実装内容の概要
- 設定モーダルからユーザーのログアウトができる機能を実装しました。
- ユーザー詳細画面からアカウント削除ができる機能を実装しました。

PC画面（ログアウト）
[![Image from Gyazo](https://i.gyazo.com/bd27b8443475ca0415a2bfc18d3785f2.gif)](https://gyazo.com/bd27b8443475ca0415a2bfc18d3785f2)

PC画面（アカウント削除）
[![Image from Gyazo](https://i.gyazo.com/72295a3a1f5a5c35cf18d2aa6a5488fe.gif)](https://gyazo.com/72295a3a1f5a5c35cf18d2aa6a5488fe)

## 技術的な詳細
- ログアウト・削除機能はdeviseの標準機能を使用しています。

## 関連Issue
Close #37 