### PR TITLE
通知機能を導入

### DIFF
--- a/app/controllers/notification_settings_controller.rb
+++ b/app/controllers/notification_settings_controller.rb
@@ -8,11 +8,11 @@ class NotificationSettingsController < ApplicationController
   def update
     # 変更前の状態を記録
     previous_state = @notification_setting.reminder_enabled
-    
+
     if @notification_setting.update(notification_setting_params)
       # 変更後の状態を取得
       current_state = @notification_setting.reminder_enabled
-      
+
       # 状態変更に応じたメッセージを設定
       if previous_state != current_state
         if current_state
@@ -23,7 +23,7 @@ class NotificationSettingsController < ApplicationController
       else
         flash[:notice] = "通知設定を確認しました。"
       end
-      
+
       head :ok
     else
       # バリデーションエラーの場合
@@ -35,7 +35,7 @@ class NotificationSettingsController < ApplicationController
   private
 
   def set_notification_setting
-    # レコードが存在しなければ作成
+      # レコードが存在しなければ作成
       @notification_setting = current_user.notification_setting ||
                           current_user.build_notification_setting(scene_type: :preset)
   end

--- a/app/controllers/notification_settings_controller.rb
+++ b/app/controllers/notification_settings_controller.rb
@@ -1,0 +1,46 @@
+class NotificationSettingsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_notification_setting, only: %i[update edit]
+
+  def edit
+  end
+
+  def update
+    # 変更前の状態を記録
+    previous_state = @notification_setting.reminder_enabled
+    
+    if @notification_setting.update(notification_setting_params)
+      # 変更後の状態を取得
+      current_state = @notification_setting.reminder_enabled
+      
+      # 状態変更に応じたメッセージを設定
+      if previous_state != current_state
+        if current_state
+          flash[:notice] = "プッシュ通知をONにしました"
+        else
+          flash[:notice] = "プッシュ通知をOFFにしました"
+        end
+      else
+        flash[:notice] = "通知設定を確認しました。"
+      end
+      
+      head :ok
+    else
+      # バリデーションエラーの場合
+      flash[:alert] = "通知設定の保存に失敗しました。#{@notification_setting.errors.full_messages.join('、')}"
+      render json: @notification_setting.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_notification_setting
+    # レコードが存在しなければ作成
+      @notification_setting = current_user.notification_setting ||
+                          current_user.build_notification_setting(scene_type: :preset)
+  end
+
+  def notification_setting_params
+    params.require(:notification_setting).permit(:reminder_enabled)
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("hello", HelloController)
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 
+import NotificationController from "./notification_controller"
+application.register("notification", NotificationController)
+
 import PhotoPreviewController from "./photo_preview_controller"
 application.register("photo-preview", PhotoPreviewController)
 

--- a/app/javascript/controllers/notification_controller.js
+++ b/app/javascript/controllers/notification_controller.js
@@ -52,12 +52,7 @@ export default class extends Controller {
       } else {
         return;
       }
-      
-      // External IDを設定
-      if (this.externalIdValue) {
-        OneSignal.User.addAlias("user_id", this.externalIdValue);
-      }
-      
+
       // トグルを有効化
       this.enableToggle(true);
     } catch (error) {

--- a/app/javascript/controllers/notification_controller.js
+++ b/app/javascript/controllers/notification_controller.js
@@ -1,0 +1,133 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = { externalId: String }
+  static targets = ["toggle", "error", "success", "loading", "errorText", "successText"]
+
+  connect() {
+    // OneSignalの読み込み待ち処理を改善
+    this.waitForOneSignal();
+  }
+
+  waitForOneSignal() {
+    // OneSignalが既に利用可能かチェック
+    if (this.isOneSignalReady()) {
+      this.setupToggle();
+      return;
+    }
+
+    // OneSignalの読み込みを待つ（最大10秒）
+    let attempts = 0;
+    const maxAttempts = 50; // 10秒 (200ms × 50回)
+    
+    const checkInterval = setInterval(() => {
+      attempts++;
+      if (this.isOneSignalReady()) {
+        clearInterval(checkInterval);
+        this.setupToggle();
+      } else if (attempts >= maxAttempts) {
+        clearInterval(checkInterval);
+        this.handleOneSignalError();
+      }
+    }, 200);
+  }
+
+  isOneSignalReady() {
+    return typeof OneSignal !== 'undefined' && 
+           OneSignal.initialized === true &&
+           OneSignal.User && 
+           OneSignal.User.PushSubscription &&
+           typeof OneSignal.User.PushSubscription.optIn === 'function';
+  }
+
+  async setupToggle() {
+    try {
+      // 現在の購読状態を取得
+      const isOptedIn = OneSignal.User.PushSubscription.optedIn;
+      
+      // トグルボタンの状態を設定
+      const toggleElement = this.element.querySelector('[data-notification-target="toggle"]');
+      if (toggleElement) {
+        toggleElement.checked = isOptedIn;
+      } else {
+        return;
+      }
+      
+      // External IDを設定
+      if (this.externalIdValue) {
+        OneSignal.User.addAlias("user_id", this.externalIdValue);
+      }
+      
+      // トグルを有効化
+      this.enableToggle(true);
+    } catch (error) {
+      this.enableToggle(false);
+    }
+  }
+
+  enableToggle(enabled) {
+    const toggleElement = this.element.querySelector('[data-notification-target="toggle"]');
+    if (toggleElement) {
+      toggleElement.disabled = !enabled;
+    }
+  }
+
+  async toggle() {
+    try {
+      // OneSignalの準備状態を確認
+      if (!this.isOneSignalReady()) {
+        this.toggleTarget.checked = !this.toggleTarget.checked;
+        return;
+      }
+      
+      const isCurrentlyOptedIn = OneSignal.User.PushSubscription.optedIn;
+      const newState = this.toggleTarget.checked;
+      
+      // 状態が変更された場合のみ処理を実行
+      if (newState !== isCurrentlyOptedIn) {
+        this.toggleTarget.disabled = true; // 処理中は無効化
+        
+        if (newState) {
+          // 通知をONにする
+          await OneSignal.User.PushSubscription.optIn();
+        } else {
+          // 通知をOFFにする
+          await OneSignal.User.PushSubscription.optOut();
+        }
+        
+        // 状態を再確認して表示を更新
+        const finalState = OneSignal.User.PushSubscription.optedIn;
+        this.toggleTarget.checked = finalState;
+        
+        // サーバーに状態を保存（必要に応じて）
+        await this.saveNotificationState(finalState);
+      }
+    } catch (error) {
+      // エラー時は元の状態に戻す
+      const currentState = OneSignal.User.PushSubscription?.optedIn || false;
+      this.toggleTarget.checked = currentState;
+      
+    } finally {
+      // トグルを再度有効化
+      this.toggleTarget.disabled = false;
+    }
+  }
+
+  // サーバーに状態を保存するメソッド
+  async saveNotificationState(enabled) {
+    try {
+      await fetch('/notification_setting', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        },
+        body: JSON.stringify({
+          notification_setting: {
+            reminder_enabled: enabled
+          }
+        })
+      });
+    } catch (error) {}
+  }
+}

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -1,0 +1,7 @@
+class NotificationSetting < ApplicationRecord
+  belongs_to :user
+
+  validates :scene_type, presence: true
+  validates :scene_name, presence: true, if: -> { scene_type == 'custom' }
+  enum scene_type: { preset: 0, custom: 1 }
+end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -2,6 +2,6 @@ class NotificationSetting < ApplicationRecord
   belongs_to :user
 
   validates :scene_type, presence: true
-  validates :scene_name, presence: true, if: -> { scene_type == 'custom' }
+  validates :scene_name, presence: true, if: -> { scene_type == "custom" }
   enum :scene_type, { preset: 0, custom: 1 }
 end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -3,5 +3,5 @@ class NotificationSetting < ApplicationRecord
 
   validates :scene_type, presence: true
   validates :scene_name, presence: true, if: -> { scene_type == 'custom' }
-  enum scene_type: { preset: 0, custom: 1 }
+  enum :scene_type, { preset: 0, custom: 1 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :diaries, dependent: :destroy
   has_many :diary_contents, through: :diaries, dependent: :destroy
-  has_one :notification_settings
+  has_one :notification_setting, dependent: :destroy
 
   has_one_attached :avatar
 
@@ -27,6 +27,13 @@ class User < ApplicationRecord
 
   def avatar_thumbnail
     self.avatar.variant(resize_to_fill: [ 100, 100 ]).processed
+  end
+
+  def onesignal_external_id!
+    return self.onesignal_external_id if self.onesignal_external_id.present?
+    
+    update!(onesignal_external_id: SecureRandom.uuid)
+    self.onesignal_external_id
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :diaries, dependent: :destroy
   has_many :diary_contents, through: :diaries, dependent: :destroy
+  has_one :notification_settings
 
   has_one_attached :avatar
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
 
   def onesignal_external_id!
     return self.onesignal_external_id if self.onesignal_external_id.present?
-    
+
     update!(onesignal_external_id: SecureRandom.uuid)
     self.onesignal_external_id
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
     <title><%= content_for(:title) || "ひだまり日記" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -18,7 +19,7 @@
     <script src="https://kit.fontawesome.com/9eebda5a5d.js" crossorigin="anonymous"></script>
     <script type="module" src="https://unpkg.com/cally"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.20.0/matter.min.js"></script>
-    <script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
+
 
     <script>
       window.OneSignalDeferred = window.OneSignalDeferred || [];

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,10 +15,19 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-    <!--fontawesome-->
     <script src="https://kit.fontawesome.com/9eebda5a5d.js" crossorigin="anonymous"></script>
     <script type="module" src="https://unpkg.com/cally"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.20.0/matter.min.js"></script>
+    <script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
+
+    <script>
+      window.OneSignalDeferred = window.OneSignalDeferred || [];
+      OneSignalDeferred.push(async function(OneSignal) {
+        await OneSignal.init({
+          appId: "916a5045-7817-411e-b961-b4447b56c7ba",
+        });
+      });
+    </script>
   </head>
 
   <body class="font-base-content font-zen_maru">

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="flex flex-col items-center max-w-5xl mx-auto px-4 mt-8">
+  <h2 class="text-2xl font-bold mb-6">通知設定</h2>
+
+  <div class="form-control"
+       data-controller="notification"
+       data-notification-external-id-value="<%= current_user.onesignal_external_id! %>">
+    
+    <div class="flex flex-col items-center">
+      <label class="cursor-pointer label">
+        <span class="label-text">プッシュ通知</span>
+        <input type="checkbox"
+               data-notification-target="toggle"
+               data-action="change->notification#toggle"
+               <%= "checked" if current_user.notification_setting&.reminder_enabled? %>
+               class="toggle toggle-accent">
+      </label>
+      
+      <!-- 状態表示 -->
+      <span data-notification-target="status" class="ml-2 mt-2">
+        <%= current_user.notification_setting&.reminder_enabled? ? "ON" : "OFF" %>
+      </span>
+    </div>
+  </div>
+</div>
+

--- a/app/views/shared/_settings_modal.html.erb
+++ b/app/views/shared/_settings_modal.html.erb
@@ -11,7 +11,7 @@
 
     <ul class="space-y-4">
       <li><%= link_to "プロフィール", user_path(current_user), class: "btn btn-outline w-full" %></li>
-      <li><%= link_to "通知設定", "#", class: "btn btn-outline w-full" %></li>
+      <li><%= link_to "通知設定",  edit_notification_setting_path, class: "btn btn-outline w-full" %></li>
       <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-error w-full" %></li>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get "public_diaries", to: "diaries#public_diaries", as: :public_diaries
 
   resources :users, only: %i[show]
+  resource :notification_settings, only:  %i[edit update]
 
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   get "public_diaries", to: "diaries#public_diaries", as: :public_diaries
 
   resources :users, only: %i[show]
-  resource :notification_settings, only:  %i[edit update]
+  resource :notification_setting, only: %i[edit update]
 
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20250915041513_add_onesignal_external_id_to_users.rb
+++ b/db/migrate/20250915041513_add_onesignal_external_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddOnesignalExternalIdToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :onesignal_external_id, :uuid
+  end
+end

--- a/db/migrate/20250915102045_create_notification_settings.rb
+++ b/db/migrate/20250915102045_create_notification_settings.rb
@@ -1,0 +1,12 @@
+class CreateNotificationSettings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notification_settings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.time :notification_time
+      t.boolean :reminder_enabled, null: false, default: false
+      t.integer :scene_type, null: false
+      t.string :scene_name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250915102045_create_notification_settings.rb
+++ b/db/migrate/20250915102045_create_notification_settings.rb
@@ -4,7 +4,7 @@ class CreateNotificationSettings < ActiveRecord::Migration[7.2]
       t.references :user, null: false, foreign_key: true
       t.time :notification_time
       t.boolean :reminder_enabled, null: false, default: false
-      t.integer :scene_type, null: false
+      t.integer :scene_type, null: false, default: 0
       t.string :scene_name
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_15_041513) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_15_102045) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_15_041513) do
     t.index ["tag_id"], name: "index_diary_tags_on_tag_id"
   end
 
+  create_table "notification_settings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.time "notification_time"
+    t.boolean "reminder_enabled", default: false, null: false
+    t.integer "scene_type", null: false
+    t.string "scene_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notification_settings_on_user_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -102,4 +113,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_15_041513) do
   add_foreign_key "diary_contents", "diaries"
   add_foreign_key "diary_tags", "diaries"
   add_foreign_key "diary_tags", "tags"
+  add_foreign_key "notification_settings", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_14_072353) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_15_041513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_14_072353) do
     t.string "provider"
     t.string "uid"
     t.text "introduction"
+    t.uuid "onesignal_external_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,7 +75,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_15_102045) do
     t.bigint "user_id", null: false
     t.time "notification_time"
     t.boolean "reminder_enabled", default: false, null: false
-    t.integer "scene_type", null: false
+    t.integer "scene_type", default: 0, null: false
     t.string "scene_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/public/OneSignalSDKWorker.js
+++ b/public/OneSignalSDKWorker.js
@@ -1,0 +1,1 @@
+importScripts("https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js");


### PR DESCRIPTION
## 実装内容の概要
- [x] OneSignalを導入し、プッシュ通知をできるように設定
- [x] フッターの設定→通知設定をおすと、通知設定画面に遷移
- [x] 通知ボタンのトグルを切り替えると、OneSignalの購買を切り替え可能

PC画面（通知の切り替え）
[![Image from Gyazo](https://i.gyazo.com/3e2d39ed59d5a52d423e39a28aef1319.gif)](https://gyazo.com/3e2d39ed59d5a52d423e39a28aef1319)

## 技術的な詳細
- **テーブル作成**
  - 通知を管理する``notification_settings``テーブルを作成しました。
-  **カラムの説明**
    - `t.references :user, null: false, foreign_key: true→ユーザーを外部キーとしています。
    - t.time :notification_time→通知時間を管理するカラム
    - t.boolean :reminder_enabled, null: false, default: false→通知ON/OFFを管理するカラム。デフォルトは、OFFにしています。
    - t.integer :scene_type, null: false, default: 0→通知のタイプを管理するカラム。enumで管理。（enum :scene_type, { preset: 0, custom: 1 }）デフォルトはpresetです。
    - t.string :scene_name →利用シーンの名前を管理するカラム。
- **ルーティング**
  - `resource :notification_setting, only: %i[edit update]`を追加。通知は１つのみ設定可能な設計なので、単数形にしています。
- **画面遷移**
  - フッターの設定→通知設定を押すと。edit_notification_setting_pathに遷移します。
- **OneSignal（プッシュ通知サービス）**
  - プッシュ通知を実装する為に、OneSignalというサービスを導入しました。
  - OneSignal SDK を読み込み、購読状態（opt-in / opt-out）の管理に利用しています。
- **Stimulus**
  -  `app/javascript/controllers/notification_controller.js`を作成。通知設定画面のトグル操作を制御しています。 
  - ユーザーがトグルを切り替えると、OneSignal.User.PushSubscription.optIn / optOut を呼び出し、購読状態を変更します。
  
## 今後の拡張
- 現状はトグルを切り替えて、リロードをしないと、情報の切り替えができません。TurboStreamで非同期化する予定です。
- 最終的にユーザーは、プリセットされている利用シーン（例：就寝前）か自身で利用シーンをカスタマイズするカスタムのどちらかを選び、自由に通知時間を設定できる機能にします。
- 作成したカラムは`reminder_enabled`のみ利用していますが、最終的な機能の為に必要なので事前に追加しています。
- wheneverを導入し、ユーザーが設定した時間にOneSignalにAPI通信をし、プッシュ通知を送る想定でいます。
## 確認事項
- [x] トグルの切り替えをすると、OneSignal側のダッシュボードでStatusがsubscribeとunsubscribeの切り替えができるかどうか
- [x] 通知をOFFからONにしリロードすると、「プッシュ通知をONにしました」というフラッシュメッセージが表示されトグルの下の表記がOFFからONに切り替わるかどうか
- [x]  通知をONからOFFにしリロードすると、「プッシュ通知をOFFにしました」というフラッシュメッセージが表示されトグルの下の表記がONからOFFに切り替わるかどうか

## 関連Issue
Close #21