### PR TITLE
日記作成ができるFABボタンを設置

### DIFF
--- a/app/javascript/controllers/fab_button_controller.js
+++ b/app/javascript/controllers/fab_button_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.lastScrollY = window.scrollY;
+    this.toggle();
+  }
+
+  toggle() {
+    window.addEventListener('scroll', this.handleScroll.bind(this));
+  }
+
+  handleScroll() {
+    if (window.scrollY > this.lastScrollY) {
+      this.element.classList.add("translate-y-20", "opacity-0");
+    } else {
+      this.element.classList.remove("translate-y-20", "opacity-0");
+    }
+    this.lastScrollY = window.scrollY;
+  }
+
+  disconnect() {
+    window.removeEventListener('scroll', this.handleScroll);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import DiaryController from "./diary_controller"
 application.register("diary", DiaryController)
 
+import FabButtonController from "./fab_button_controller"
+application.register("fab-button", FabButtonController)
+
 import FlashMessageController from "./flash_message_controller"
 application.register("flash-message", FlashMessageController)
 

--- a/app/views/diaries/my_diaries.html.erb
+++ b/app/views/diaries/my_diaries.html.erb
@@ -14,7 +14,5 @@
     <% end %>
   </div>
   
-  <div class="mt-8 text-center">
-    <%= link_to '日記を書く', new_diary_path, class: "btn btn-primary btn-lg" %>
-  </div>
+  <%= render 'shared/fab_button' %>
 </div>

--- a/app/views/diaries/public_diaries.html.erb
+++ b/app/views/diaries/public_diaries.html.erb
@@ -13,4 +13,6 @@
       </div>
     <% end %>
   </div>
+
+  <%= render 'shared/fab_button' %>
 </div>

--- a/app/views/shared/_fab_button.html.erb
+++ b/app/views/shared/_fab_button.html.erb
@@ -1,0 +1,7 @@
+<div class="fixed bottom-20 right-4 z-50 transition-transform duration-300 ease-in-out transform translate-y-0 md:right-1/7" data-controller="fab-button">
+  <%= link_to new_diary_path, class: "btn btn-primary btn-circle btn-lg shadow-lg" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+    </svg>
+  <% end %>
+</div>


### PR DESCRIPTION
## 実装内容の概要
- 日記作成ができるFABボタンを実装しました。
- ユーザーの操作の邪魔にならないように、FABボタンは下スクロール時は非表示に、上にスクロール時は表示するように設定ししています。
- スマホ画面ではFABボタンを右下に、PC画面では少しだけ中央に寄せています。

### PC画面（FABボタンの挙動）
[![Image from Gyazo](https://i.gyazo.com/0b32724a7fd93a89bdcc909b35defc50.gif)](https://gyazo.com/0b32724a7fd93a89bdcc909b35defc50)

### スマホ画面（FABボタンの挙動）
[![Image from Gyazo](https://i.gyazo.com/d7f14062c314fd6eed0f75b66d34d501.gif)](https://gyazo.com/d7f14062c314fd6eed0f75b66d34d501)

## 技術的な詳細
- `app/views/shared/_fab_button.html.erb`を作成し、FABボタンを再利用できるようにしています。
- マイ日記画面（app/views/diaries/my_diaries.html.erb）みんなの日記画面（app/views/diaries/public_diaries.html.erb）に上記パーシャルを利用し、FABボタンを設置しています。
- `app/javascript/controllers/fab_button_controller.js`を作成し、FABボタンを制御しています。
  - スクロール方向を判定し、下スクロール時にはtranslate-y-20とopacity-0クラスを追加することでボタンを非表示に、上スクロール時にはこれらのクラスを削除して再表示させています。

## 確認事項
- [x] マイ日記画面にFABボタンが表示されており、下スクロール時はFABボタンが非表示に、上スクロール時はFABボタンが表示されているかどうか
- [x] みんなの日記画面にFABボタンが表示されており、下スクロール時はFABボタンが非表示に、上スクロール時はFABボタンが表示されているかどうか
- [x] スマホ画面でも同様の挙動になるかどうか

## 関連Issue
Close #85 