### PR TITLE
diary_streakメソッドを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,12 +39,13 @@ class User < ApplicationRecord
     dates = diaries.order(posted_date: :desc).pluck(:posted_date)
     return 0 if dates.empty?
 
-    count = 0
-    previous_date = Date.today
+    count = 1
+    previous_date = dates.first
 
-    dates.each do |date|
-      if previous_date - date == count
+    dates.drop(1).each do |date|
+      if previous_date - date == 1
         count += 1
+        previous_date = date
       else
         break
       end


### PR DESCRIPTION
## 変更内容
- 日記の継続日数をカウントするdiary_streakメソッドを変更しました。

理由:以前のものは、 `previous_date = Date.today`や`if previous_date - date == count`この部分の意味がわかりにくく、良くない内容だっため新しいものに修正しました。

説明:日記のデータがなければ0
1つでもあればカウントを1としています。
dates.drop(1)というのは最初の1つの要素を除いた（捨てた）新しい配列を返すものです。
これがないと、9月25日に日記を投稿すると、previous_date = 9月25日, date= 9月25日となり、メソッドが成り立たない為、最初の要素は捨て、それ以外をeachで回すというようにしています。
例：dates = [9月25日, 9月24日, 9月23日]
9月25日(previous_date) - 9月24日 =1なので、countは2になります。previous_dateは9月24日に更新され、次に9月23日と比較し、1になるのでcountが3になる。

previous_date - date == 1にならない時点で、breakで終了します。

