### PR TITLE
日記更新後の幸せ瓶の幸せの数を修正

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -36,7 +36,7 @@ class DiariesController < ApplicationController
     new_happiness_count = @diary_form.happiness_count
 
       if new_happiness_count > 0
-        current_total = current_user.diary_contents.count
+        current_total = current_user.total_happiness_count
         previous_total = current_total - new_happiness_count
 
        flash[:happiness_animation] = {
@@ -59,6 +59,7 @@ class DiariesController < ApplicationController
     @diary_form = DiaryForm.from_diary(@diary)
     @diary_form.assign_attributes(diary_form_params)
     previous_happiness_count = @diary.diary_contents.count
+    previous_total_happiness = current_user.total_happiness_count
 
     if @diary_form.update(@diary)
       new_happiness_count = @diary_form.happiness_count
@@ -68,7 +69,7 @@ class DiariesController < ApplicationController
         flash[:happiness_animation] = {
           type: happiness_diff > 0 ? "increase" : "decrease",
           count: happiness_diff.abs,
-          previous_total: previous_happiness_count
+          previous_total: previous_total_happiness
         }
       end
 

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -11,7 +11,7 @@ class HomesController < ApplicationController
 
     ]
 
-    @existing_happiness_count = current_user.diary_contents.count
+    @existing_happiness_count = current_user.total_happiness_count
 
     animation_data = flash[:happiness_animation] || {}
     if animation_data.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,10 @@ class User < ApplicationRecord
     count
   end
 
+  def total_happiness_count
+    diaries.sum(:happiness_count)
+  end
+
   private
 
   def validate_avatar_format


### PR DESCRIPTION
## 実装内容の概要
- 日記更新後幸せ瓶の幸せの数が、更新した日記分しか表示されなかったため、トータルの幸せの数が表示されるように修正しました。

## 変更内容
- **パフォーマンス改善 (app/models/user.rb)**
User モデルに `total_happiness_count` メソッドを追加しました。

理由: 以前は` current_user.diary_contents.count `で幸せの総計を取得していましたが、レコードが増えると処理負荷が高くなる問題がありました。その為、各日記の `happiness_count `カラムの値を合計する` diaries.sum(:happiness_count)` を利用し、高速化を図りました。
 
- **コントローラーの修正 (app/controllers/diaries_controller.rb)**
DiariesController#update アクションの` flash[:happiness_animation] `の設定を修正しました。

変更前: `previous_total` に、更新する日記の幸せ数 (previous_happiness_count) を渡していた。

変更後: `previous_total `に、更新前のユーザーのトータルの幸せ数 (previous_total_happiness) を渡すように修正しました。
```
# DiariesController#update (修正箇所)
flash[:happiness_animation] = {
  type: happiness_diff > 0 ? "increase" : "decrease",
  count: happiness_diff.abs,
  previous_total: previous_total_happiness # <-- ユーザー総計に修正
}
```

## 動作確認手順
以下の手順で、総計に基づいたアニメーションが正しく動作することを確認しました。

ユーザーが既に 3個 の幸せ（例：日記Aに1個、日記Bに2個）を持っている状態にします。

日記Bを編集し、幸せの項目を1つ追加し、合計 4個 にします（総計の差分は +1）。

日記を更新後、リダイレクトされたホーム画面でアニメーションを確認します。

結果: 既存の 3個 の幸せの上に、1個 の幸せが落ちてきて、最終的に 4個 になることを確認。

[![Image from Gyazo](https://i.gyazo.com/5d9e4a970ea8f94a756201a60852ac1f.gif)](https://gyazo.com/5d9e4a970ea8f94a756201a60852ac1f)


## 関連Issue
Close #97 