### PR TITLE
レイアウトの修正

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -32,6 +32,6 @@
     </div>
 
     <div class="w-full mt-8">
-      <%= f.submit "更新", class: "btn btn-primary btn-lg w-full max-w-sm mx-auto block font-bold " %>
+      <%= f.submit "更新", class: "btn btn-primary w-full max-w-sm mx-auto block font-bold" %>
     </div>
   <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -32,6 +32,6 @@
     </div>
 
     <div class="w-full mt-8">
-      <%= f.submit "更新", class: "btn btn-primary w-full" %>
+      <%= f.submit "更新", class: "btn btn-primary btn-lg w-full max-w-sm mx-auto block font-bold " %>
     </div>
   <% end %>

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -113,7 +113,7 @@
         <%= f.text_field :tag_names, placeholder: "タグを複数つけるには','かスペースで区切ってください。", class: "input w-full" %>
       </div>
         
-      <%= f.submit @diary_form.persisted? ? "更新" : "投稿する", class: "btn btn-primary mt-8 w-full btn-lg font-bold" %>
+      <%= f.submit @diary_form.persisted? ? "更新" : "投稿する", class: "btn btn-primary mt-8 w-full btn-lg  max-w-sm mx-auto block font-bold" %>
     </div>
   <% end %>
 

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -63,13 +63,7 @@
       </template>
     </div>
 
-    <!-- タグ -->
-    <div class="mt-8 space-x-2">
-      <%= f.label :tag_names, "タグ" %>
-      <%= f.text_field :tag_names, placeholder: "タグを複数つけるには','かスペースで区切ってください。", class: "input w-full" %>
-    </div>
-
-    <div class="flex flex-col items-center mt-4">
+    <div class="flex flex-col items-center space-y-4">
       <!-- 写真追加 -->
       <div data-controller="photo-preview">
         <div data-photo-preview-target="preview" 
@@ -112,8 +106,14 @@
           <%= f.radio_button :status, :is_private, class: "hidden", checked: @diary_form.status == 'is_private' %>
         </div>
       </div>
-      
-      <%= f.submit @diary_form.persisted? ? "更新する" : "投稿する", class: "btn btn-primary btn-lg mt-8" %>
+
+      <!-- タグ -->
+      <div class="space-x-2 w-full">
+        <%= f.label :tag_names, "タグ" %>
+        <%= f.text_field :tag_names, placeholder: "タグを複数つけるには','かスペースで区切ってください。", class: "input w-full" %>
+      </div>
+        
+      <%= f.submit @diary_form.persisted? ? "更新" : "投稿する", class: "btn btn-primary mt-8 w-full btn-lg font-bold" %>
     </div>
   <% end %>
 

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -113,7 +113,7 @@
         <%= f.text_field :tag_names, placeholder: "タグを複数つけるには','かスペースで区切ってください。", class: "input w-full" %>
       </div>
         
-      <%= f.submit @diary_form.persisted? ? "更新" : "投稿する", class: "btn btn-primary mt-8 w-full btn-lg  max-w-sm mx-auto block font-bold" %>
+      <%= f.submit @diary_form.persisted? ? "更新" : "投稿する", class: "btn btn-primary mt-8 w-full max-w-sm mx-auto block font-bold" %>
     </div>
   <% end %>
 

--- a/app/views/pages/diary_writing_tips.html.erb
+++ b/app/views/pages/diary_writing_tips.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="space-y-12">
-      <section class="card bg-white shadow-sm ring-1 ring-black/5 dark:bg-neutral-800 dark:ring-white/10 fade-in" style="animation-delay: 0.3s;">
+      <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.3s;">
         <div class="card-body p-6 sm:p-8">
           <h2 class="card-title mb-4 text-xl md:text-2xl font-bold text-base-content">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">lightbulb</span>日々の小さな幸せを記録する
@@ -26,7 +26,7 @@
         </div>
       </section>
 
-      <section class="card bg-white shadow-sm ring-1 ring-black/5 dark:bg-neutral-800 dark:ring-white/10 fade-in" style="animation-delay: 0.5s;">
+      <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.5s;">
         <div class="card-body p-6 sm:p-8">
           <h2 class="card-title mb-4 text-xl md:text-2xl font-bold text-base-content">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">self_improvement</span>こんなことを書いてみよう
@@ -67,7 +67,7 @@
         </div>
       </section>
 
-      <section class="card bg-white shadow-sm ring-1 ring-black/5 dark:bg-neutral-800 dark:ring-white/10 fade-in" style="animation-delay: 0.7s;">
+      <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.7s;">
         <div class="card-body p-6 sm:p-8">
           <h2 class="card-title mb-4 text-xl md:text-2xl font-bold text-base-content">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">event_repeat</span>習慣化のコツ

--- a/app/views/pages/diary_writing_tips.html.erb
+++ b/app/views/pages/diary_writing_tips.html.erb
@@ -105,7 +105,7 @@
       </section>
 
       <div class="mt-12 flex justify-center fade-in" style="animation-delay: 0.9s;">
-        <%= link_to new_diary_path, class: "btn btn-primary p-6 text-lg font-semibold transition-transform hover:scale-105" do %>
+        <%= link_to new_diary_path, class: "btn btn-primary p-6 font-semibold transition-transform hover:scale-105" do %>
           <span class="material-symbols-outlined"> edit_note </span>
           <span>日記を書いてみる</span>
         <% end %>

--- a/app/views/pages/diary_writing_tips.html.erb
+++ b/app/views/pages/diary_writing_tips.html.erb
@@ -1,11 +1,11 @@
-<div class="flex-1 px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+<div class="flex-1 px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20 leading-relaxed">
   <div class="mx-auto max-w-4xl">
 
     <div class="mb-12 text-center fade-in" style="animation-delay: 0.1s;">
-      <h1 class="mb-4 text-3xl font-bold tracking-tight text-base-content md:text-5xl">
+      <h1 class="mb-4 font-mplus text-3xl font-bold tracking-tight text-primary md:text-5xl leading-tight">
         ひだまり日記の書き方ガイド
       </h1>
-      <p class="mx-auto max-w-2xl text-md md:text-lg text-secondary-content">
+      <p class="mx-auto max-w-2xl text-base md:text-lg">
         毎日の小さな幸せを見つけて、心を豊かにする習慣をはじめましょう。
       </p>
     </div>
@@ -13,54 +13,54 @@
     <div class="space-y-12">
       <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.3s;">
         <div class="card-body p-6 sm:p-8">
-          <h2 class="card-title mb-4 text-xl md:text-2xl font-bold text-base-content">
+          <h2 class="card-title mb-4 text-xl md:text-2xl font-bold leading-tight">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">lightbulb</span>日々の小さな幸せを記録する
           </h2>
-          <p class="text-base leading-relaxed text-secondary-content">
+          <p class="text-base">
             何気ない日常の中に隠れている幸せを見つけ、それを記録することで、よりポジティブな気持ちで毎日を過ごせるようになります。
           </p>
           <div class="mt-6 space-y-3 pl-4 border-l-2 border-primary/50">
-            <p class="text-secondary-content"><strong class="font-semibold text-primary">ポイント：</strong>出来事＋感謝・幸せの気持ちを添えましょう</p>
-            <p class="text-secondary-content"><strong class="font-semibold text-primary">例：</strong>「おいしいご飯をたべた」→「おいしいご飯をたべれて、幸せ！ありがとう！」</p>
+            <p><strong class="font-semibold text-primary text-base">ポイント：</strong>出来事＋感謝・幸せの気持ちを添えましょう</p>
+            <p><strong class="font-semibold text-primary text-base">例：</strong>「おいしいご飯をたべた」→「おいしいご飯をたべれて、幸せ！ありがとう！」</p>
           </div>
         </div>
       </section>
 
       <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.5s;">
         <div class="card-body p-6 sm:p-8">
-          <h2 class="card-title mb-4 text-xl md:text-2xl font-bold text-base-content">
-            <span class="material-symbols-outlined align-bottom text-primary mr-2">self_improvement</span>こんなことを書いてみよう
+          <h2 class="card-title mb-4 text-xl md:text-2xl font-bold leading-tight">
+            <span class="material-symbols-outlined align-bottom text-primary mr-2">stylus_note</span>こんなことを書いてみよう
           </h2>
-          <p class="mb-6 text-base leading-relaxed text-secondary-content">
+          <p class="mb-6 text-base">
             何を書こうか迷ったときは、次のようなことを思い出してみると書きやすくなります。
           </p>
           <ul class="space-y-4 list-none">
             <li class="flex items-start">
               <span class="material-symbols-outlined text-primary mt-1 mr-3 flex-shrink-0">check_circle</span>
               <div>
-                <h3 class="font-semibold text-base-content">今日あった良いこと</h3>
-                <p class="text-sm text-secondary-content">大きなことでなくても大丈夫。心が温かくなった瞬間を思い出してみましょう。</p>
+                <h3 class="font-semibold text-base md:text-lg">今日あった良いこと</h3>
+                <p class="text-sm md:text-base">大きなことでなくても大丈夫。心が温かくなった瞬間を思い出してみましょう。</p>
               </div>
             </li>
             <li class="flex items-start">
               <span class="material-symbols-outlined text-primary mt-1 mr-3 flex-shrink-0">volunteer_activism</span>
               <div>
-                <h3 class="font-semibold text-base-content">感謝したいこと</h3>
-                <p class="text-sm text-secondary-content">人、物、出来事など、感謝の気持ちを具体的に書き出すことで、幸福感が高まります。</p>
+                <h3 class="font-semibold text-base md:text-lg">感謝したいこと</h3>
+                <p class="text-sm md:text-base">人、物、出来事など、感謝の気持ちを具体的に書き出すことで、幸福感が高まります。</p>
               </div>
             </li>
             <li class="flex items-start">
               <span class="material-symbols-outlined text-primary mt-1 mr-3 flex-shrink-0">workspace_premium</span>
               <div>
-                <h3 class="font-semibold text-base-content">自分を褒める</h3>
-                <p class="text-sm text-secondary-content">「よく頑張ったね」と、今日の自分を承認してあげることで、自己肯定感が高まります。</p>
+                <h3 class="font-semibold text-base md:text-lg">自分を褒める</h3>
+                <p class="text-sm md:text-base">「よく頑張ったね」と、今日の自分を承認してあげることで、自己肯定感が高まります。</p>
               </div>
             </li>
             <li class="flex items-start">
               <span class="material-symbols-outlined text-primary mt-1 mr-3 flex-shrink-0">flag</span>
               <div>
-                <h3 class="font-semibold text-base-content">明日の小さな目標</h3>
-                <p class="text-sm text-secondary-content">「朝5分だけ散歩する」など、簡単な目標を立てることで、前向きな一日を始められます。</p>
+                <h3 class="font-semibold text-base md:text-lg">明日の小さな目標</h3>
+                <p class="text-sm md:text-base">「朝5分だけ散歩する」など、簡単な目標を立てることで、前向きな一日を始められます。</p>
               </div>
             </li>
           </ul>
@@ -69,45 +69,45 @@
 
       <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.7s;">
         <div class="card-body p-6 sm:p-8">
-          <h2 class="card-title mb-4 text-xl md:text-2xl font-bold text-base-content">
+          <h2 class="card-title mb-4 text-xl md:text-2xl font-bold leading-tight">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">event_repeat</span>習慣化のコツ
           </h2>
-          <p class="mb-6 text-base leading-relaxed text-secondary-content">
+          <p class="mb-6 text-base">
             日記を続けるための、ちょっとした工夫をご紹介します。
           </p>
-          <ul class="space-y-4">
+          <ul class="space-y-4 text-base">
             <li class="flex items-start gap-3">
               <div class="flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-primary flex-shrink-0 mt-1">
-                <span class="text-sm font-bold">1</span>
+                <span class="font-bold">1</span>
               </div>
-              <p class="text-secondary-content"><strong class="font-semibold">時間を決める：</strong>「寝る前の3分」など、毎日同じ時間に書くリズムを作りましょう。</p>
+              <p><strong class="font-semibold text-base md:text-lg">時間を決める：</strong>「寝る前の3分」など、毎日同じ時間に書くリズムを作りましょう。</p>
             </li>
             <li class="flex items-start gap-3">
               <div class="flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-primary flex-shrink-0 mt-1">
-                <span class="text-sm font-bold">2</span>
+                <span class="font-bold">2</span>
               </div>
-              <p class="text-secondary-content"><strong class="font-semibold">短くてもOK：</strong>完璧を目指さず、一言だけでも大丈夫。まずは「毎日開く」ことを目標に。</p>
+              <p><strong class="font-semibold text-base md:text-lg">短くてもOK：</strong>完璧を目指さず、一言だけでも大丈夫。まずは「毎日開く」ことを目標に。</p>
             </li>
             <li class="flex items-start gap-3">
               <div class="flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-primary flex-shrink-0 mt-1">
-                <span class="text-sm font-bold">3</span>
+                <span class="font-bold">3</span>
               </div>
-              <p class="text-secondary-content"><strong class="font-semibold">リマインダーを活用：</strong>アプリの通知機能を使えば、書き忘れを防げます。</p>
+              <p><strong class="font-semibold text-base md:text-lg">リマインダーを活用：</strong>アプリの通知機能を使えば、書き忘れを防げます。</p>
             </li>
             <li class="flex items-start gap-3">
               <div class="flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-primary flex-shrink-0 mt-1">
-                <span class="text-sm font-bold">4</span>
+                <span class="font-bold">4</span>
               </div>
-              <p class="text-secondary-content"><strong class="font-semibold">無理をしない：</strong>とても落ち込んだときは、無理に前向きにならなくても大丈夫。過去の日記を開いて、小さな喜びや自分の頑張りをそっと思い出してみましょう。きっと心がやわらぎます。</p>
+              <p><strong class="font-semibold text-base md:text-lg">無理をしない：</strong>とても落ち込んだときは、無理に前向きにならなくても大丈夫。過去の日記を開いて、小さな喜びや自分の頑張りをそっと思い出してみましょう。きっと心がやわらぎます。</p>
             </li>
           </ul>
         </div>
       </section>
 
       <div class="mt-12 flex justify-center fade-in" style="animation-delay: 0.9s;">
-        <%= link_to new_diary_path, class: "btn btn-primary p-6 transition-transform hover:scale-105" do %>
+        <%= link_to new_diary_path, class: "btn btn-primary p-6 text-lg font-semibold transition-transform hover:scale-105" do %>
           <span class="material-symbols-outlined"> edit_note </span>
-          <span class="truncate">日記を書いてみる</span>
+          <span>日記を書いてみる</span>
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_fab_button.html.erb
+++ b/app/views/shared/_fab_button.html.erb
@@ -1,6 +1,6 @@
 <div class="fixed bottom-20 right-4 z-50 transition-transform duration-300 ease-in-out transform translate-y-0 md:right-1/7" data-controller="fab-button">
-  <%= link_to new_diary_path, class: "btn btn-primary btn-circle btn-lg shadow-lg" do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <%= link_to new_diary_path, class: "btn btn-primary btn-circle w-14 h-14 shadow-lg" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
     </svg>
   <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -16,8 +16,8 @@
     <% end %>
 
     <div data-controller="modal">
-      <button data-action="click->modal#open" class="flex flex-col items-center">
-        <i class="fa-solid fa-gear text-2xl md:text-3xl text-gray-500 hover:text-primary"></i>
+      <button data-action="click->modal#open" class="flex flex-col items-center cursor-pointer">
+        <i class="fa-solid fa-gear text-2xl md:text-3xl text-gray-500"></i>
         <span class="text-xs text-gray-500 mt-1"><%= t('.links.settings')%></span>
       </button>
 

--- a/app/views/shared/_settings_modal.html.erb
+++ b/app/views/shared/_settings_modal.html.erb
@@ -9,7 +9,7 @@
               data-action="click->modal#close">✕</button>
     </div>
 
-    <ul class="space-y-4">
+    <ul class="space-y-6">
       <li><%= link_to "プロフィール", user_path(current_user), class: "btn btn-outline w-full" %></li>
       <li><%= link_to "通知設定",  edit_notification_setting_path, class: "btn btn-outline w-full" %></li>
       <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-error w-full" %></li>


### PR DESCRIPTION
## 変更内容
- ひだまり日記書き方ガイドページ
  - [x] ユーザーのデバイスがダークモードの時の表示を修正※MVP後ダークモードの切り替えを実装するので、その際に対応。
  - [x] こんなことを書いてみようのアイコンをself_improvementからstylus_noteに変更。
  - [x] 文字サイズを適切な大きさに修正
  - [x] 文字数が多いページなので、全体に`leading-relaxed`を追加し行間をゆったりめに修正。
- フッター
  - [x] フッターの設定アイコンだけホバーすると色が変っていたのを修正
  - [x] 設定モーダル内のボタンの間隔が少し狭く、スマホで押しずらいと感じたので、間隔を少し広めに修正
- ボタン
  - [x] FABボタンの大きさを大きく、＋の文字色を白に修正
  - [x] 日記フォームとユーザー編集の更新ボタンの大きさを修正
  - [x] ボタンの文字を更新する→更新に修正
- 日記フォーム
  - [x] 以前は、日記のフォームにボタンなどの要素が３つ縦に並んでいた為、投稿する・更新ボタンが目立たなかった。タグの入力フィールドを投稿する・更新ボタンの前にすることで、ボタンが目立つようになりました。

### ひだまり日記書き方ガイド
PC画面
[![Image from Gyazo](https://i.gyazo.com/c554df4e0158c4c0f576d040ebb41fd5.gif)](https://gyazo.com/c554df4e0158c4c0f576d040ebb41fd5)

スマホ画面
[![Image from Gyazo](https://i.gyazo.com/1b2544564d9f75cc8f1800ce0874bf33.gif)](https://gyazo.com/1b2544564d9f75cc8f1800ce0874bf33)

### 日記フォーム
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/00f7cbdb-1dbd-4f69-908b-fcea3e59b073" />

## 関連Issue
Close #99 