### PR TITLE
通知設定時間を15分単位に変更・通知するユーザーを取得するSQL文を効率的に修正

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -22,6 +22,9 @@ application.register("modal", ModalController)
 import NotificationController from "./notification_controller"
 application.register("notification", NotificationController)
 
+import NotificationTimeController from "./notification_time_controller"
+application.register("notification-time", NotificationTimeController)
+
 import PasswordVisibilityController from "./password_visibility_controller"
 application.register("password-visibility", PasswordVisibilityController)
 
@@ -33,4 +36,3 @@ application.register("scene", SceneController)
 
 import StatusSelectorController from "./status_selector_controller"
 application.register("status-selector", StatusSelectorController)
-

--- a/app/javascript/controllers/notification_time_controller.js
+++ b/app/javascript/controllers/notification_time_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input"]
+
+  connect() {
+    this.inputTarget.addEventListener("change", this.roundTo15Minutes.bind(this))
+  }
+
+  roundTo15Minutes(event) {
+    const [hour, minute] = event.target.value.split(":").map(Number)
+    const rounded = [0, 15, 30, 45].reduce((prev, curr) => Math.abs(curr - minute) < Math.abs(prev - minute) ? curr : prev)
+    event.target.value = `${hour.toString().padStart(2,'0')}:${rounded.toString().padStart(2,'0')}`
+  }
+}

--- a/app/jobs/diary_reminder_job.rb
+++ b/app/jobs/diary_reminder_job.rb
@@ -14,7 +14,7 @@ class DiaryReminderJob < ApplicationJob
     # 通知時間が一致するユーザーだけを取得
     users_to_notify = User.joins(:notification_setting)
                       .where(notification_settings: { reminder_enabled: true })
-                      .where("to_char(notification_settings.notification_time, 'HH24:MI') = ?", current_hour_minute)
+                      .where(notification_settings: { notification_time: current_hour_minute })
 
     users_to_notify.each do |user|
       if user.onesignal_external_id.present?

--- a/app/jobs/diary_reminder_job.rb
+++ b/app/jobs/diary_reminder_job.rb
@@ -8,36 +8,20 @@ class DiaryReminderJob < ApplicationJob
   def perform
     Rails.logger.info "DiaryReminderJob started at #{Time.current.in_time_zone('Asia/Tokyo').strftime('%Y-%m-%d %H:%M:%S %z')}"
 
-    # 通知時間が設定されていてリマインダー有効なユーザーを取得
-    users = User.joins(:notification_setting)
-                .where(notification_settings: { reminder_enabled: true })
-                .where.not(notification_settings: { notification_time: nil })
-
     current_time_in_jst = Time.current.in_time_zone("Asia/Tokyo")
+    current_hour_minute = current_time_in_jst.strftime('%H:%M')
 
-    users.each do |user|
-      user_setting = user.notification_setting
-      next unless user_setting && user_setting.notification_time
+    # 通知時間が一致するユーザーだけを取得
+    users_to_notify = User.joins(:notification_setting)
+                      .where(notification_settings: { reminder_enabled: true })
+                      .where("to_char(notification_settings.notification_time, 'HH24:MI') = ?", current_hour_minute)
 
-      # 今日のJSTに合わせて通知時間を設定
-      user_notification_time_today_jst = current_time_in_jst.change(
-        hour: user_setting.notification_time.hour,
-        min: user_setting.notification_time.min,
-        sec: 0
-      )
-
-      # 現在時刻の「時」と「分」が通知時間と一致するかチェック
-      if current_time_in_jst.hour == user_notification_time_today_jst.hour &&
-         current_time_in_jst.min == user_notification_time_today_jst.min
-
-        if user.onesignal_external_id.present?
-          Rails.logger.info "Attempting to send notification to user ID: #{user.id} (External ID: #{user.onesignal_external_id}) for scheduled time: #{user_setting.notification_time.strftime('%H:%M')}"
-          send_one_signal_notification(user)
-        else
-          Rails.logger.warn "User ID: #{user.id} has no OneSignal External ID. Skipping notification."
-        end
+    users_to_notify.each do |user|
+      if user.onesignal_external_id.present?
+        Rails.logger.info "Attempting to send notification to user ID: #{user.id} (External ID: #{user.onesignal_external_id}) for scheduled time: #{user.notification_setting.notification_time.strftime('%H:%M')}"
+        send_one_signal_notification(user)
       else
-        Rails.logger.info "User ID: #{user.id}'s notification time #{user_setting.notification_time.strftime('%H:%M')} is not the current minute. (Current: #{current_time_in_jst.strftime('%H:%M')})"
+        Rails.logger.warn "User ID: #{user.id} has no OneSignal External ID. Skipping notification."
       end
     end
 

--- a/app/jobs/diary_reminder_job.rb
+++ b/app/jobs/diary_reminder_job.rb
@@ -9,7 +9,7 @@ class DiaryReminderJob < ApplicationJob
     Rails.logger.info "DiaryReminderJob started at #{Time.current.in_time_zone('Asia/Tokyo').strftime('%Y-%m-%d %H:%M:%S %z')}"
 
     current_time_in_jst = Time.current.in_time_zone("Asia/Tokyo")
-    current_hour_minute = current_time_in_jst.strftime('%H:%M')
+    current_hour_minute = current_time_in_jst.strftime("%H:%M")
 
     # 通知時間が一致するユーザーだけを取得
     users_to_notify = User.joins(:notification_setting)

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -9,7 +9,7 @@ class NotificationSetting < ApplicationRecord
 
   def notification_time_must_be_15_min_interval
     return unless notification_time
-    unless [0, 15, 30, 45].include?(notification_time.min)
+    unless [ 0, 15, 30, 45 ].include?(notification_time.min)
       errors.add(:notification_time, "は15分単位で設定してください")
     end
   end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -1,6 +1,7 @@
 class NotificationSetting < ApplicationRecord
   belongs_to :user
 
+  validates :notification_time, presence: true, if: :reminder_enabled?
   validates :scene_type, presence: true
   validates :scene_name, presence: true, if: -> { scene_type == "custom" }
   enum :scene_type, { preset: 0, custom: 1 }

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -4,4 +4,13 @@ class NotificationSetting < ApplicationRecord
   validates :scene_type, presence: true
   validates :scene_name, presence: true, if: -> { scene_type == "custom" }
   enum :scene_type, { preset: 0, custom: 1 }
+
+  validate :notification_time_must_be_15_min_interval
+
+  def notification_time_must_be_15_min_interval
+    return unless notification_time
+    unless [0, 15, 30, 45].include?(notification_time.min)
+      errors.add(:notification_time, "は15分単位で設定してください")
+    end
+  end
 end

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -78,8 +78,8 @@
         </div>
       </div>
 
-      <div class="flex items-center justify-center">
-        <%= f.submit "保存する", class: "btn btn-primary" %>
+      <div class="flex items-center justify-center mt-10">
+        <%= f.submit "保存", class: "btn btn-primary w-full max-w-sm mx-auto block font-bold" %>
       </div>
     <% end %>
   </div>

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -70,11 +70,12 @@
           </div>
         </div>
         
-        <div class="form-control mt-6">
+        <div class="form-control mt-6" data-controller="notification-time">
           <label class="label">
-            <span class="label-text">通知時間</span>
+            <span class="label-text font-semibold">通知時間</span>
           </label>
-          <%= f.time_field :notification_time, class: "input input-bordered w-full max-w-xs" %>
+          <p class="text-sm mt-1">※選択した時間は15分単位に調整されます。</p>
+          <%= f.time_field :notification_time, class: "input input-bordered w-full max-w-xs mt-4", data: { notification_time_target: "input" } %>
         </div>
       </div>
 

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -2,7 +2,8 @@
      data-controller="notification">
 
   <h2 class="font-mplus text-2xl font-bold mb-2">通知設定</h2>
-    
+    <p class="text-sm mb-4">※iOS端末は通知機能が未対応です。</p>
+
     <div class="flex flex-col items-center">
       <label class="cursor-pointer label">
         <span class="label-text">プッシュ通知</span>

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -70,7 +70,7 @@
           </div>
         </div>
         
-        <div class="form-control mt-6" data-controller="notification-time">
+        <div class="form-control mt-10" data-controller="notification-time">
           <label class="label">
             <span class="label-text font-semibold">通知時間</span>
           </label>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,4 +5,8 @@ ja:
         photos: 写真
         tag_names: タグ
   activerecord:
+    models:
+      notification_setting: 通知設定
     attributes:
+      notification_setting:
+        notification_time: 設定時間

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,3 +10,5 @@ ja:
     attributes:
       notification_setting:
         notification_time: 設定時間
+        scene_type: 利用シーンのタイプ
+        scene_name: シーン名

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,6 +16,6 @@ set :job_template, "/bin/bash -l -c ':job'"
 job_type :runner, "cd :path && /usr/local/bundle/bin/bundle exec rails runner -e :environment ':task' :output"
 
 # 1分ごとにジョブ実行
-every 1.minutes do
+every 15.minutes do
   rake "diary_reminder:remind"
 end

--- a/db/migrate/20250930010107_add_index_to_notification_settings_notification_time.rb
+++ b/db/migrate/20250930010107_add_index_to_notification_settings_notification_time.rb
@@ -1,0 +1,5 @@
+class AddIndexToNotificationSettingsNotificationTime < ActiveRecord::Migration[7.2]
+  def change
+    add_index :notification_settings, :notification_time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_15_102045) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_30_010107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_15_102045) do
     t.string "scene_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["notification_time"], name: "index_notification_settings_on_notification_time"
     t.index ["user_id"], name: "index_notification_settings_on_user_id"
   end
 


### PR DESCRIPTION
## 実装内容の概要
- 通知設定時間を1分単位から15分単位に変更しました。
変更理由:通知を設定するユーザー少数と予想され、1分単位にするとコストがかかってしまうため、15分単位で様子をみることにしました。
- ユーザーが15分単位外の数字を設定した場合は、自動的に近い15分単位の数字に調整されるようになっています。

- 通知するユーザーを取得するSQL文を効率化。
- 通知設定をONにしたユーザーは通知時間の設定が必須のバリデーションを追加。

- notification_settingsテーブルのカラムをi18n化。
- 通知機能がiOS端末に未対応なことを表示。
- ボタンを「保存する」から「保存」に変更し、大きさを大きくしました。

### 通知設定画面（見やすいように表示部分のみ）
[![Image from Gyazo](https://i.gyazo.com/00a10df2eab417dd37b6e31a6ced0425.gif)](https://gyazo.com/00a10df2eab417dd37b6e31a6ced0425)

## 技術的な詳細
**通知するユーザー取得に関するもの**
- 以前は通知をONにしているユーザーを取得し、そのデータを１つ１つ現在時刻と設定時間が一致するかを確認していましたが、これだと非効率の為、通知をONにしているユーザーかつ現在時刻と設定時間が一致するかを先に取得するように変更し、効率化を図りました。
- それに伴い、`notification_time`のindexを追加しました。（MVP段階であり、ユーザー数も大人数ではないことから複合インデックスは採用しませんでした）

**UI**
- 設定時間を15分単位にすることにおいて、セレクトボックスを検討しましたが、時間と分数のボックスが分かれてしまい入力にすこし手間がかかると感じた為、既存の入力方法でStimulusを利用し15分単位外の値が入力されても15分単位に自動で調整されるようにしました。
- エラーメッセージ表示の際に日本語で表示されない部分があったのでi18n化対応しました。
## 関連Issue
Close #106 