### PR TITLE
diary-reminder-jobの通知ロジック改善（±1分許容 & ログ強化）

### DIFF
--- a/app/jobs/diary_reminder_job.rb
+++ b/app/jobs/diary_reminder_job.rb
@@ -33,6 +33,7 @@ class DiaryReminderJob < ApplicationJob
       else
         Rails.logger.warn "User ID: #{user.id} has no OneSignal External ID. Skipping notification."
       end
+      Rails.logger.info "User #{user.id} reminder_enabled=#{user.notification_setting.reminder_enabled}, notification_time=#{user.notification_setting.notification_time}"
     end
 
     Rails.logger.info "DiaryReminderJob finished."

--- a/app/jobs/diary_reminder_job.rb
+++ b/app/jobs/diary_reminder_job.rb
@@ -25,7 +25,7 @@ class DiaryReminderJob < ApplicationJob
                       )
 
 
-    Rails.logger.info "Users to notify count: #{users_to_notify.count}"                  
+    Rails.logger.info "Users to notify count: #{users_to_notify.count}"
     users_to_notify.each do |user|
       if user.onesignal_external_id.present?
         Rails.logger.info "Attempting to send notification to user ID: #{user.id} (External ID: #{user.onesignal_external_id}) for scheduled time: #{user.notification_setting.notification_time.strftime('%H:%M')}"


### PR DESCRIPTION
## 実装内容の概要
- 通知時間と現在時間を、分数で比較。
- 通知時間の判定を ±1分の範囲で許容するように修正。
- 各ユーザーの通知設定内容をログに出すデバッグを追加。

## 技術的な詳細
- 以前のコードだと、strftime("%H:%M")で文字列の10：00を作って、それをDBのtime型と比較していました。DBは10:00:00と秒数まで一致することを期待していた為、通知時間が一致するユーザー数が見つからない可能性がありました。なので文字列ではなく、現在の時刻とDBどちらも分単位の整数に変換し比較するように変更しました。これにより、秒数は無視されます。
- `BETWEEN   current_minutes - 1 AND  current_minutes + 1` で1分前後の誤差を許容し、実行タイミングのズレにも対応しています。

- ユーザーの通知設定をログに出力することで、通知が届かない原因の切り分けをします。
