### PR TITLE
ユーザーを取得するSQL文にタイムゾーンをJSTに変換するように明示

### DIFF
--- a/app/jobs/diary_reminder_job.rb
+++ b/app/jobs/diary_reminder_job.rb
@@ -19,7 +19,7 @@ class DiaryReminderJob < ApplicationJob
     users_to_notify = User.joins(:notification_setting)
                       .where(notification_settings: { reminder_enabled: true })
                       .where(
-                        "(EXTRACT(HOUR FROM notification_settings.notification_time) * 60 + EXTRACT(MINUTE FROM notification_settings.notification_time))
+                        "(EXTRACT(HOUR FROM notification_settings.notification_time AT TIME ZONE 'Asia/Tokyo') * 60 + EXTRACT(MINUTE FROM notification_settings.notification_time AT TIME ZONE 'Asia/Tokyo'))
                         BETWEEN ? AND ?",
                         current_minutes - 1, current_minutes + 1
                       )


### PR DESCRIPTION
## 実装内容の概要
- `app/jobs/diary_reminder_job.rb`ファイルの通知対象のユーザーを取得するSQL文に` `AT TIME ZONE 'Asia/Tokyo'` `を追加

## 技術的な詳細
- 本番環境のDBを確認するとタイムゾーンがUTCでした。これにより現在時間（JST）とnotification_time(UTC)で差異があった為、プッシュ通知が届かない事象が発生していたと考えられます。
また開発環境のDBのタイムゾーンはJSTになっていた為、開発環境では問題なく動作しておりました。

## 備考
- Neon の DB タイムゾーンは変更できないため、アプリ側で `AT TIME ZONE 'Asia/Tokyo'` を明示する方針としました。
