### PR TITLE
fix:DBのタイムゾーンをJSTにできなかった為、UTCで統一

### DIFF
--- a/app/jobs/diary_reminder_job.rb
+++ b/app/jobs/diary_reminder_job.rb
@@ -11,15 +11,13 @@ class DiaryReminderJob < ApplicationJob
     Rails.logger.info "Time.zone.name: #{Time.zone.name}"
     Rails.logger.info "Time.current.in_time_zone('Asia/Tokyo'): #{Time.current.in_time_zone('Asia/Tokyo')}"
 
-
-    current_time_in_jst = Time.current.in_time_zone("Asia/Tokyo")
-    current_minutes = current_time_in_jst.hour * 60 + current_time_in_jst.min
+    current_minutes = Time.current.utc.hour * 60 + Time.current.utc.min
 
     # 通知時間が一致するユーザーだけを取得
     users_to_notify = User.joins(:notification_setting)
                       .where(notification_settings: { reminder_enabled: true })
                       .where(
-                        "(EXTRACT(HOUR FROM notification_settings.notification_time AT TIME ZONE 'Asia/Tokyo') * 60 + EXTRACT(MINUTE FROM notification_settings.notification_time AT TIME ZONE 'Asia/Tokyo'))
+                        "(EXTRACT(HOUR FROM notification_settings.notification_time) * 60 + EXTRACT(MINUTE FROM notification_settings.notification_time))
                         BETWEEN ? AND ?",
                         current_minutes - 1, current_minutes + 1
                       )

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module Myapp
     # in config/environments, which are processed later.
     #
     config.time_zone = "Asia/Tokyo"
-    config.active_record.default_timezone = :local
+    config.active_record.default_timezone = :utc
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.generators do |g|


### PR DESCRIPTION
## 実装内容の概要
- 以前のプルリクエスト（https://github.com/tamagoyaki00/hidamarinikki/pull/112）　
で変更した部分が期待通りに動作せず、通知ユーザーが見つからない問題を解決するため、比較基準をUTCに統一しました。

変更理由: Render/Neon環境において、time型カラムではAT TIME ZONE句がおそらく日付がないため`AT TIME ZONE 'Asia/Tokyo'`と指定しても、UTCからかわらず、JSTでの時刻比較が困難であったため、UTCでの比較に方針転換しました。

## 技術的な詳細
- Ruby側で取得する現在時刻を `Time.current.utc` に変更しました。
これによりDBに保存されているnotification_time(UTC)とタイムゾーンが一致し、通知が届くことが予想されます。