### PR TITLE
日記一覧画面の写真を押すとモーダルで拡大表示できるように実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,6 +31,9 @@ application.register("password-visibility", PasswordVisibilityController)
 import PhotoPreviewController from "./photo_preview_controller"
 application.register("photo-preview", PhotoPreviewController)
 
+import PhotoModalController from "./photo_modal_controller"
+application.register("photo-modal", PhotoModalController)
+
 import SceneController from "./scene_controller"
 application.register("scene", SceneController)
 

--- a/app/javascript/controllers/photo_modal_controller.js
+++ b/app/javascript/controllers/photo_modal_controller.js
@@ -1,0 +1,66 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "slide", "counter", "previousButton", "nextButton"]
+  static values = {
+    images: Array,
+    index: Number
+  }
+
+  connect() {
+
+  }
+
+  indexValueChanged() {
+    this.showSlide()
+  }
+
+  open(event) {
+    this.indexValue = Number(event.params.index)
+    this.modalTarget.showModal()
+  }
+
+  close() {
+    this.modalTarget.close()
+  }
+
+  next() {
+    this.indexValue = (this.indexValue + 1) % this.imagesValue.length
+  }
+
+  previous() {
+    this.indexValue = (this.indexValue - 1 + this.imagesValue.length) % this.imagesValue.length
+  }
+
+  showSlide() {
+    const imageUrl = this.imagesValue[this.indexValue]
+    this.slideTarget.src = imageUrl
+    this.counterTarget.textContent = `${this.indexValue + 1} / ${this.imagesValue.length}`
+
+    if (this.imagesValue.length <= 1) {
+      this.previousButtonTarget.classList.add("hidden")
+      this.nextButtonTarget.classList.add("hidden")
+    } else {
+      this.previousButtonTarget.classList.remove("hidden")
+      this.nextButtonTarget.classList.remove("hidden")
+    }
+  }
+
+  keyPress(event) {
+    if (event.key === "ArrowRight") {
+      this.next()
+    }
+    if (event.key === "ArrowLeft") {
+      this.previous()
+    }
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.modalTarget) {
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/photo_modal_controller.js
+++ b/app/javascript/controllers/photo_modal_controller.js
@@ -7,36 +7,38 @@ export default class extends Controller {
     index: Number
   }
 
-  connect() {
-
-  }
-
   indexValueChanged() {
     this.showSlide()
   }
 
+  // サムネイルクリック時にモーダルを開き、表示開始インデックスを設定する
   open(event) {
     this.indexValue = Number(event.params.index)
     this.modalTarget.showModal()
   }
 
+  // モーダルを閉じる
   close() {
     this.modalTarget.close()
   }
 
+  // 次の画像に切り替える（インデックスを増やす）
   next() {
     this.indexValue = (this.indexValue + 1) % this.imagesValue.length
   }
 
+  // 前の画像に切り替える（インデックスを減らす）
   previous() {
     this.indexValue = (this.indexValue - 1 + this.imagesValue.length) % this.imagesValue.length
   }
 
+  // スライドの画像とカウンターを更新する
   showSlide() {
     const imageUrl = this.imagesValue[this.indexValue]
     this.slideTarget.src = imageUrl
     this.counterTarget.textContent = `${this.indexValue + 1} / ${this.imagesValue.length}`
 
+    // 画像が1枚以下の場合、ナビゲーションボタンを非表示にする
     if (this.imagesValue.length <= 1) {
       this.previousButtonTarget.classList.add("hidden")
       this.nextButtonTarget.classList.add("hidden")
@@ -46,18 +48,27 @@ export default class extends Controller {
     }
   }
 
+  // キーボード操作
   keyPress(event) {
-    if (event.key === "ArrowRight") {
-      this.next()
-    }
-    if (event.key === "ArrowLeft") {
-      this.previous()
-    }
-    if (event.key === "Escape") {
-      this.close()
+    if (!this.modalTarget.open) return;
+
+    switch (event.code) {
+      case "ArrowRight":
+        this.next();
+        event.preventDefault();
+        break;
+      case "ArrowLeft":
+        this.previous();
+        event.preventDefault();
+        break;
+      case "Escape":
+        this.close();
+        event.preventDefault();
+        break;
     }
   }
 
+  // モーダルの背景（backdrop）をクリックしたときに閉じる
   closeOnBackdrop(event) {
     if (event.target === this.modalTarget) {
       this.close()

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -6,6 +6,7 @@ class Diary < ApplicationRecord
 
   has_many_attached :photos do |attachable|
     attachable.variant :thumb, resize_to_limit: [ 200, 200 ]
+    attachable.variant :display, resize_to_limit: [ 1024, 1024 ]
   end
 
   validates :happiness_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -52,16 +52,62 @@
           </ol>
           
           <!-- 写真 -->
-          <% if diary.photos.attached? %>
-            <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
-              <% diary.photos.each do |photo| %>
-                <div class="relative w-full">
-                  <%= image_tag photo.variant(:thumb), class: "w-full h-full object-contain rounded-lg shadow-sm" %>
-                </div>
-              <% end %>
+          <div
+            data-controller="photo-modal"
+            data-photo-modal-images-value="<%= diary.photos.map { |p| url_for(p.variant(:display)) }.to_json %>"
+            data-action="keydown.window->photo-modal#keyPress">
+
+            <% if diary.photos.attached? %>
+              <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
+                <% diary.photos.each_with_index do |photo, index| %>
+                  <div class="relative w-full cursor-pointer">
+                    <%#
+                      - actionを "photo-modal#open" に変更
+                      - paramを "photo-modal-index-param" に変更
+                    %>
+                    <%= image_tag photo.variant(:thumb),
+                                  class: "w-full h-full object-contain rounded-lg shadow-sm",
+                                  data: {
+                                    action: "click->photo-modal#open",
+                                    photo_modal_index_param: index
+                                  } %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+
+          <dialog data-photo-modal-target="modal" data-action="click->photo-modal#closeOnBackdrop" class="modal">
+            <div class="modal-box w-11/12 max-w-5xl p-0 md:p-4 relative">
+              
+              <!-- 閉じるボタン -->
+              <button data-action="click->photo-modal#close"
+                      class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 z-10">✕</button>
+
+              <!-- 画像表示 -->
+              <div class="flex items-center justify-center">
+                <img data-photo-modal-target="slide"
+                    src=""
+                    alt="拡大画像"
+                    class="max-h-[80vh] w-auto object-contain">
+              </div>
+
+              <!-- ナビゲーションを画像の下に配置 -->
+              <div class="flex items-center justify-center gap-4 mt-4">
+                <button data-photo-modal-target="previousButton"
+                        data-action="click->photo-modal#previous"
+                        class="btn btn-circle">❮</button>
+                <span data-photo-modal-target="counter"
+                      class="text-lg font-mono w-20 text-center"></span>
+                <button data-photo-modal-target="nextButton"
+                        data-action="click->photo-modal#next"
+                        class="btn btn-circle">❯</button>
+              </div>
+
             </div>
-          <% end %>
-        </div>
+            <form method="dialog" class="modal-backdrop">
+              <button>close</button>
+            </form>
+          </dialog>
         
         <!-- タグと公開ステータス -->
         <div class="mt-4">

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -55,7 +55,7 @@
           <div
             data-controller="photo-modal"
             data-photo-modal-images-value="<%= diary.photos.map { |p| url_for(p.variant(:display)) }.to_json %>"
-            data-action="keydown.window->photo-modal#keyPress">
+            data-action="keydown@window->photo-modal#keyPress">
 
             <% if diary.photos.attached? %>
               <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">


### PR DESCRIPTION
## 実装内容の概要
- 日記一覧画面の写真を押すと、モーダルで写真が拡大表示されるように実装しました。
- 画像が複数枚ある場合はモーダル内の左右の矢印またはキーボードの矢印（←→）で画像の切り替えが可能です。

## 実装理由
- 一覧画面では写真が小さく見ずらかった為。
### 写真モーダル
PC画面
[![Image from Gyazo](https://i.gyazo.com/f6baa710a1217f486692d5a18070fa38.gif)](https://gyazo.com/f6baa710a1217f486692d5a18070fa38)

スマホ画面
[![Image from Gyazo](https://i.gyazo.com/a14c1dd29ee991725179aa17f4e0ca97.gif)](https://gyazo.com/a14c1dd29ee991725179aa17f4e0ca97)
## 技術的な詳細
**Stimulus**
- app/javascript/controllers/photo_modal_controller.jsを作成し、モーダル操作、画像切り替え、キーボード操作を実装しました。

**Active Storage Variant の追加**
- `app/models/diary.rb`に拡大表示用のバリアント` :display, resize_to_limit: [1024, 1024]` を追加しました。

## 確認内容
- [x] 写真のサムネイルをクリックするとモーダルが開き、拡大画像が表示される
- [x] 左右ボタンで前後の写真に移動できる
- [x] 矢印（←→）のキーボードで前後の写真に移動できる
- [x] Esc キーや backdrop クリックで閉じられる
- [x] スマホでもレイアウトが崩れないことを確認

## 関連Issue
Close #114 