### PR TITLE
ログイン状態に応じたルートページの切り替えと remember_me の有効化

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,10 @@ class User < ApplicationRecord
     diaries.sum(:happiness_count)
   end
 
+  def remember_me
+    true
+  end
+
   private
 
   def validate_avatar_format

--- a/app/views/shared/_fab_button.html.erb
+++ b/app/views/shared/_fab_button.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed bottom-20 right-4 z-50 transition-transform duration-300 ease-in-out transform translate-y-0 md:right-1/7" data-controller="fab-button">
+<div class="fixed bottom-20 right-4 z-40 transition-transform duration-300 ease-in-out transform translate-y-0 md:right-1/7" data-controller="fab-button">
   <%= link_to new_diary_path, class: "btn btn-primary btn-circle w-14 h-14 shadow-lg" do %>
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks"
   }
 
-  root "pages#top"
   get "top", to: "pages#top"
   get "diary/writing_tips", to: "pages#diary_writing_tips"
   get "home", to: "homes#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-
   authenticated :user do
     root to: "homes#index", as: :authenticated_root
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,13 @@
 Rails.application.routes.draw do
+
+  authenticated :user do
+    root to: "homes#index", as: :authenticated_root
+  end
+
+  unauthenticated do
+    root to: "pages#top", as: :unauthenticated_root
+  end
+
   devise_for :users, controllers: {
     registrations: "users/registrations",
     omniauth_callbacks: "users/omniauth_callbacks"


### PR DESCRIPTION
## 実装内容の概要
- ユーザーがブラウザを閉じても、ログイン状態が維持されるように実装しました。
- ログイン状態に応じて root ページを切り替えるように修正しました。
- 未ログイン時: pages#top
- ログイン済み時: homes#index

**小さな変更**
- ハンバーガーメニューを開けたときにFABボタンと被って表示されていたので、FABボタンをメニューの下に表示するように修正しました。

## 技術的な詳細
- **remember_me の有効化**
- Userモデルに`def remember_me; true; end` を定義することで、ログインした全ユーザーのログイン状態を維持するようにしました。これによりブラウザを閉じてもセッションが維持されます。

**ルートページの切り替え**
- `authenticated :user` は Devise が提供している DSL で、ユーザーのログイン状態（user_signed_in?） を見てルーティングを切り替えてくれます。
- root は ログイン済み → `homes#index`
- 未ログイン → `pages#top` に自動で分岐します。


確認事項
- [x] ログイン後に新しいタブで root を開いた場合、home_path に遷移すること
- [x] 未ログイン状態で root を開いた場合、top_path に遷移すること
- [x] ブラウザを閉じてもログイン状態が維持されること

## 関連Issue
Close #117