### PR TITLE
ユーザー新規登録画面とログイン画面のレイアウトを修正

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -122,6 +122,6 @@
     <% end %>
 
     <div class="divider"></div>
-    <%= link_to "アカウントをお持ちの方はこちら", new_session_path(resource_name), class: "text-sm hover:underline" %>
+    <%= link_to "ログインはこちら", new_session_path(resource_name), class: "text-sm hover:underline" %>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
-<div class="h-screen flex items-center justify-center">
-  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 shadow-xl p-8 flex items-center justify-center flex-col space-y-8">
+<div class="flex items-center justify-center mt-0 md:mt-10 px-0 md:px-4">
+  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 rounded-none shadow-none md:shadow-xl md:rounded-4xl p-8 flex items-center justify-center flex-col space-y-8">
     <h2 class="font-mplus text-xl md:text-2xl font-bold"><%= t('devise.registrations.new.title') %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "flex flex-col space-y-8 items-center" }) do |f| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
-<div class="h-screen flex items-center justify-center">
-  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 shadow-xl p-8 flex items-center justify-center flex-col space-y-8">
+<div class="flex items-center justify-center mt-0 md:mt-10 px-0 md:px-4">
+  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 rounded-none shadow-none md:shadow-xl md:rounded-4xl p-8 flex items-center justify-center flex-col space-y-8">
     <h2 class="font-mplus text-xl md:text-2xl font-bold"><%= t('devise.sessions.new.title') %></h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col space-y-8 items-center" }) do |f| %>
@@ -54,7 +54,7 @@
     <% end %>
 
     <div class="divider"></div>
-    <p>お持ちのアカウントで登録</p>
+    <p>お持ちのアカウントでログイン</p>
 
     <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-white text-black border-[#e5e5e5]" do %>
       <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -133,12 +133,12 @@ ja:
         sign_up: 新規登録
       minimum_password_length:
         other: "（%{count}文字以上）"
-      name: "名前"
+      name: "ユーザー名"
       email: "メールアドレス"
       password: "パスワード"
       password_confirmation: "パスワード（確認用）"
       placeholders:
-        name: "名前を入力"
+        name: "ユーザー名を入力"
         email: "mail@site.com"
         password: "パスワードを入力"
         password_confirmation: "もう一度パスワードを入力"


### PR DESCRIPTION
## 実装内容の概要
- デバイスによって新規登録画面のレイアウトが崩れている問題を修正しました。
- 「名前」を「ユーザー名」に変更しました。
- 新規登録画面の「アカウントをお持ちの方はこちら」を「ログインはこちら」に変更しました。
- ログイン画面の「お持ちのアカウントで登録」を「お持ちのアカウントでログイン」に変更しました。
- 新規登録画面・ログイン画面はスマホ画面のみカード形式ではなくフルスクリーンで表示させました。
### 新規登録画面
スマホ
<img width="380" height="815" alt="スクリーンショット 2025-10-03 175040" src="https://github.com/user-attachments/assets/7e747e4f-83a1-4dda-9f45-8ee83db7cd7c" />

### ログイン画面
スマホ
<img width="376" height="811" alt="スクリーンショット 2025-10-03 175148" src="https://github.com/user-attachments/assets/45a62d9b-664c-4276-81a8-dfd098f3b860" />

## 技術的な詳細
- views/layouts/application.html.erbの<main>セクションにすでに`min-h-screen`を設定していたにも関わらず、`app/views/devise/registrations/new.html.erb` ` app/views/devise/sessions/new.html.erb`に`h-screen`を設定していたことがおそらく原因で、デバイスによってレイアウトが崩れていたと思われます。（自身のデバイスでは問題がなく、開発者ツールでも問題の確認とれないため、修正ができているか確認できておりません。）

**UI**
- それぞれの文字の修正に関しては、そちらのほうが分かりやすいと感じた為、修正しました。
- またスマートフォンでは、カード形式よりもフルスクリーンのほうが見やすい為、変更しました。
## 関連Issue
Close #120 