### PR TITLE
ダークモードを実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,7 +6,7 @@
 @plugin "daisyui/theme" {
   name: "hidamarinikki";
   default: true;
-  prefersdark: true;
+  prefersdark: false;
   color-scheme: "light";
   --color-base-100: #FFFAE8;
   --color-base-200: #F7F2E2;
@@ -42,7 +42,7 @@
 @plugin "daisyui/theme" {
   name: "sunset";
   default: false;
-  prefersdark: false;
+  prefersdark: true;
   color-scheme: "dark";
   --color-base-100: oklch(22% 0.019 237.69);
   --color-base-200: oklch(20% 0.019 237.69);

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -39,20 +39,21 @@
 }
 
 
+
 @plugin "daisyui/theme" {
   name: "sunset";
   default: false;
   prefersdark: true;
   color-scheme: "dark";
-  --color-base-100: oklch(22% 0.019 237.69);
+  --color-base-100: oklch(18% 0.019 237.69);
   --color-base-200: oklch(20% 0.019 237.69);
-  --color-base-300: oklch(18% 0.019 237.69);
+  --color-base-300: oklch(22% 0.019 237.69);
   --color-base-content: oklch(77.383% 0.043 245.096);
   --color-primary: oklch(74.703% 0.158 39.947);
   --color-primary-content: oklch(14.94% 0.031 39.947);
-  --color-secondary: oklch(72.537% 0.177 2.72);
+  --color-secondary: #FFB347;
   --color-secondary-content: oklch(14.507% 0.035 2.72);
-  --color-accent: oklch(71.294% 0.166 299.844);
+  --color-accent: #E91E63;
   --color-accent-content: oklch(14.258% 0.033 299.844);
   --color-neutral: oklch(26% 0.019 237.69);
   --color-neutral-content: oklch(70% 0.019 237.69);
@@ -73,6 +74,7 @@
   --depth: 0;
   --noise: 0;
 }
+
 
 
 @theme {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -38,6 +38,43 @@
   --noise: 0;
 }
 
+
+@plugin "daisyui/theme" {
+  name: "sunset";
+  default: false;
+  prefersdark: false;
+  color-scheme: "dark";
+  --color-base-100: oklch(22% 0.019 237.69);
+  --color-base-200: oklch(20% 0.019 237.69);
+  --color-base-300: oklch(18% 0.019 237.69);
+  --color-base-content: oklch(77.383% 0.043 245.096);
+  --color-primary: oklch(74.703% 0.158 39.947);
+  --color-primary-content: oklch(14.94% 0.031 39.947);
+  --color-secondary: oklch(72.537% 0.177 2.72);
+  --color-secondary-content: oklch(14.507% 0.035 2.72);
+  --color-accent: oklch(71.294% 0.166 299.844);
+  --color-accent-content: oklch(14.258% 0.033 299.844);
+  --color-neutral: oklch(26% 0.019 237.69);
+  --color-neutral-content: oklch(70% 0.019 237.69);
+  --color-info: oklch(85.559% 0.085 206.015);
+  --color-info-content: oklch(17.111% 0.017 206.015);
+  --color-success: oklch(85.56% 0.085 144.778);
+  --color-success-content: oklch(17.112% 0.017 144.778);
+  --color-warning: oklch(85.569% 0.084 74.427);
+  --color-warning-content: oklch(17.113% 0.016 74.427);
+  --color-error: oklch(85.511% 0.078 16.886);
+  --color-error-content: oklch(17.102% 0.015 16.886);
+  --radius-selector: 1rem;
+  --radius-field: 2rem;
+  --radius-box: 2rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 0;
+  --noise: 0;
+}
+
+
 @theme {
   /* フォント */
   --font-zen_maru: "Zen Maru Gothic", sans-serif;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -15,7 +15,7 @@
   --color-primary: #ff9966;
   --color-primary-content: #333333;
   --color-secondary: #FFC78A;
-  --color-secondary-content: #333333;
+  --color-secondary-content: #FDFBF7;
   --color-accent: #88b04b;
   --color-accent-content: #333333;
   --color-neutral: #FFB5A7;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -9,7 +9,7 @@
   prefersdark: false;
   color-scheme: "light";
   --color-base-100: #FFFAE8;
-  --color-base-200: #F7F2E2;
+  --color-base-200: #FDFBF7;
   --color-base-300: #E9E4D3;
   --color-base-content: #333333;
   --color-primary: #ff9966;

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -28,14 +28,17 @@ application.register("notification-time", NotificationTimeController)
 import PasswordVisibilityController from "./password_visibility_controller"
 application.register("password-visibility", PasswordVisibilityController)
 
-import PhotoPreviewController from "./photo_preview_controller"
-application.register("photo-preview", PhotoPreviewController)
-
 import PhotoModalController from "./photo_modal_controller"
 application.register("photo-modal", PhotoModalController)
+
+import PhotoPreviewController from "./photo_preview_controller"
+application.register("photo-preview", PhotoPreviewController)
 
 import SceneController from "./scene_controller"
 application.register("scene", SceneController)
 
 import StatusSelectorController from "./status_selector_controller"
 application.register("status-selector", StatusSelectorController)
+
+import ThemeController from "./theme_controller"
+application.register("theme", ThemeController)

--- a/app/javascript/controllers/photo_preview_controller.js
+++ b/app/javascript/controllers/photo_preview_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
       
       const deleteButton = document.createElement('button')
       deleteButton.type = 'button'
-      deleteButton.className = 'absolute top-2 right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold shadow-lg delete-existing-btn'
+      deleteButton.className = 'absolute top-2 right-2 bg-red-500 hover:bg-red-600 text-secondary-content rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold shadow-lg delete-existing-btn'
       deleteButton.innerHTML = '×'
       deleteButton.dataset.action = 'click->photo-preview#removeExisting'
       deleteButton.dataset.photoId = photoDiv.dataset.photoId
@@ -68,7 +68,7 @@ export default class extends Controller {
         <img src="${e.target.result}" 
             class="w-full h-32 sm:h-40 md:h-48 lg:h-56 object-cover rounded-lg shadow-sm hover:shadow-md transition-all duration-200">
         <button type="button" 
-                class="absolute top-1 right-1 sm:top-2 sm:right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-5 h-5 sm:w-6 sm:h-6 flex items-center justify-center text-xs sm:text-sm font-bold shadow-lg transition-all duration-200 z-10"
+                class="absolute top-1 right-1 sm:top-2 sm:right-2 bg-red-500 hover:bg-red-600 text-secondary-content rounded-full w-5 h-5 sm:w-6 sm:h-6 flex items-center justify-center text-xs sm:text-sm font-bold shadow-lg transition-all duration-200 z-10"
                 data-action="click->photo-preview#removeNew"
                 data-index="${index}">
           ×

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["toggle"]
+
+  static values = {
+    light: { type: String, default: "hidamarinikki" },
+    dark: { type: String, default: "sunset" },
+  }
+
+  connect() {
+    const savedTheme = localStorage.getItem("theme")
+
+    // 保存されたテーマがあれば適用、なければOSの設定を確認
+    if (savedTheme) {
+      this.applyTheme(savedTheme)
+    } else {
+      // OSがダークモードを優先しているかチェック
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+      this.applyTheme(prefersDark ? this.darkValue : this.lightValue)
+    }
+  }
+
+  toggle(event) {
+    const theme = event.target.checked ? this.darkValue : this.lightValue
+    this.applyTheme(theme)
+    localStorage.setItem("theme", theme) // 選択したテーマをlocalStorageに保存
+  }
+
+  // テーマを適用し、トグルの状態を更新するヘルパーメソッド
+  applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme)
+
+    // トグル（チェックボックス）の状態を現在のテーマに合わせる
+    // ページ読み込み時に正しい表示にするために必要
+    this.toggleTarget.checked = (theme === this.darkValue)
+  }
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,12 +23,12 @@
     <!-- ユーザー名 -->
     <div class="w-full mt-8">
       <%= f.label :name, class: "font-medium mb-2" %>
-      <%= f.text_field :name, class: "input input-bordered bg-white w-full" %>
+      <%= f.text_field :name, class: "input input-bordered bg-base-200 w-full" %>
     </div>
 
     <div class="w-full mt-8">
       <%= f.label :introduction, class: "font-medium mb-2" %>
-      <%= f.text_area :introduction, placeholder: "200文字まで", class: "textarea textarea-bordered textarea-profile bg-white lg:w-[1024px]" %>
+      <%= f.text_area :introduction, placeholder: "200文字まで", class: "textarea textarea-bordered textarea-profile bg-200 lg:w-[1024px]" %>
     </div>
 
     <div class="w-full mt-8">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="flex items-center justify-center mt-0 md:mt-10 px-0 md:px-4">
-  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 rounded-none shadow-none md:shadow-xl md:rounded-4xl p-8 flex items-center justify-center flex-col space-y-8">
+  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 rounded-none shadow-none dark:bg-none dark:bg-base-200 md:shadow-xl md:rounded-4xl p-8 flex items-center justify-center flex-col space-y-8">
     <h2 class="font-mplus text-xl md:text-2xl font-bold"><%= t('devise.registrations.new.title') %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "flex flex-col space-y-8 items-center" }) do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -108,7 +108,7 @@
     <div class="divider"></div>
     <p>お持ちのアカウントで登録</p>
 
-    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-base-200 text-black border-[#e5e5e5]" do %>
+    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-white text-black border-[#e5e5e5]" do %>
       <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g>
           <path d="m0 0H512V512H0" fill="#fff"></path>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -108,7 +108,7 @@
     <div class="divider"></div>
     <p>お持ちのアカウントで登録</p>
 
-    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-white text-black border-[#e5e5e5]" do %>
+    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-base-200 text-black border-[#e5e5e5]" do %>
       <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g>
           <path d="m0 0H512V512H0" fill="#fff"></path>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="flex items-center justify-center mt-0 md:mt-10 px-0 md:px-4">
-  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 rounded-none shadow-none md:shadow-xl md:rounded-4xl p-8 flex items-center justify-center flex-col space-y-8">
+  <div class="card w-full max-w-lg bg-gradient-to-b from-secondary to-base-100 dark:bg-none dark:bg-base-200 rounded-none shadow-none md:shadow-xl md:rounded-4xl p-8 flex items-center justify-center flex-col space-y-8">
     <h2 class="font-mplus text-xl md:text-2xl font-bold"><%= t('devise.sessions.new.title') %></h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col space-y-8 items-center" }) do |f| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -56,7 +56,7 @@
     <div class="divider"></div>
     <p>お持ちのアカウントでログイン</p>
 
-    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-white text-black border-[#e5e5e5]" do %>
+    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-base-200 text-black border-[#e5e5e5]" do %>
       <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g>
           <path d="m0 0H512V512H0" fill="#fff"></path>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -56,7 +56,7 @@
     <div class="divider"></div>
     <p>お持ちのアカウントでログイン</p>
 
-    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-base-200 text-black border-[#e5e5e5]" do %>
+    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn bg-white text-black border-[#e5e5e5]" do %>
       <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g>
           <path d="m0 0H512V512H0" fill="#fff"></path>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,4 +1,4 @@
-<div class="card bg-white shadow-xl mb-6">
+<div class="card bg-base-200 shadow-xl mb-6">
   <div class="card-body p-6">
     <div class="flex items-start gap-4">
       <div class="flex-none">

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-col items-center justify-center p-4">
   <div class="max-w-md mx-auto my-8">
-    <%= link_to new_diary_path, class: "card card-body bg-secondary shadow-xl rounded-lg p-6 text-center" do %>
-      <h2 class="text-xl font-bold mb-2">日記を書く</h2>
+    <%= link_to new_diary_path, class: "card card-body bg-primary shadow-xl rounded-lg p-6 text-center" do %>
+      <h2 class="text-xl text-primary-content font-bold mb-2">日記を書く</h2>
       <p class="text-base text-gray-700">今日あった良かったことや、<br>
         ちょっと頑張ったことなどを書いてみよう！</p>
     <% end %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -20,7 +20,7 @@
 
       <div class="w-full flex justify-center">
         <div id="bottle-container"
-            class="relative w-[300px] h-[450px] border-2 border-accent rounded-md bg-white bg-opacity-70 shadow-lg overflow-hidden">
+            class="relative w-[300px] h-[450px] border-2 border-accent rounded-md bg-base-200 bg-opacity-70 shadow-lg overflow-hidden">
 
           <canvas id="happiness-canvas" 
                   width="300" 
@@ -36,7 +36,7 @@
     <!-- 継続日数 -->
     <div class="flex flex-col items-center mt-8">
       <span class="text-xl font-semibold">継続日数</span>
-      <div class="text-4xl font-bold p-8 bg-white rounded-2xl border-2 border-primary shadow-md mt-2">
+      <div class="text-4xl font-bold p-8 bg-base-200 rounded-2xl border-2 border-primary shadow-md mt-2">
         <%= current_user.diary_streak %>日
       </div>
     </div>  
@@ -44,7 +44,7 @@
       <!-- 幸せのかけら-->
     <div class="flex flex-col items-center mt-8">
       <span class="text-xl font-semibold">幸せのかけら</span>
-      <div class="text-4xl font-bold p-8 bg-white rounded-2xl border-2 border-primary shadow-md mt-2">
+      <div class="text-4xl font-bold p-8 bg-base-200 rounded-2xl border-2 border-primary shadow-md mt-2">
         <%= @existing_happiness_count %>個
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
       <%= render 'shared/header' %>
     <% end %>
     <%= render 'shared/flash_message' %>
-    <main class="min-h-screen pb-20">
+    <main class="min-h-screen pb-20 dark:bg-base-200">
       <%= yield %>
     </main>
     

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
       <%= render 'shared/header' %>
     <% end %>
     <%= render 'shared/flash_message' %>
-    <main class="min-h-screen pb-20 dark:bg-base-200">
+    <main class="min-h-screen pb-20">
       <%= yield %>
     </main>
     

--- a/app/views/pages/diary_writing_tips.html.erb
+++ b/app/views/pages/diary_writing_tips.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="space-y-12">
-      <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.3s;">
+      <section class="card bg-base-200 shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.3s;">
         <div class="card-body p-6 sm:p-8">
           <h2 class="card-title mb-4 text-xl md:text-2xl font-bold leading-tight">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">lightbulb</span>日々の小さな幸せを記録する
@@ -26,7 +26,7 @@
         </div>
       </section>
 
-      <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.5s;">
+      <section class="card bg-base-200 shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.5s;">
         <div class="card-body p-6 sm:p-8">
           <h2 class="card-title mb-4 text-xl md:text-2xl font-bold leading-tight">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">stylus_note</span>こんなことを書いてみよう
@@ -67,7 +67,7 @@
         </div>
       </section>
 
-      <section class="card bg-white shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.7s;">
+      <section class="card bg-base-200 shadow-sm ring-1 ring-black/5 fade-in" style="animation-delay: 0.7s;">
         <div class="card-body p-6 sm:p-8">
           <h2 class="card-title mb-4 text-xl md:text-2xl font-bold leading-tight">
             <span class="material-symbols-outlined align-bottom text-primary mr-2">event_repeat</span>習慣化のコツ

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full min-h-screen bg-base-100 dark:bg-base-200 flex flex-col items-center justify-center overflow-hidden">
+<div class="w-full min-h-screen flex flex-col items-center justify-center overflow-hidden">
 
   <!-- タイトル・サブタイトル-->
   <div class="text-center px-6">
@@ -29,7 +29,7 @@
 </div>
 
 <!-- 特徴 -->
-  <section id="features" class="py-20 px-6 bg-white/70 dark:bg-base-200">
+  <section id="features" class="py-20 px-6 bg-white/70 dark:bg-base-100">
     <h2 class="font-mplus text-3xl font-bold text-center mb-12 text-primary">
       ひだまり日記の6つの特徴
     </h2>
@@ -86,7 +86,7 @@
   </section>
 
   <!-- 投稿例 -->
-  <section class="py-20 px-6 dark:bg-base-200">
+  <section class="py-20 px-6">
     <div class="max-w-4xl mx-auto">
       <h2 class="font-mplus text-3xl font-bold text-center mb-8 text-primary">
         日記の投稿例
@@ -130,7 +130,7 @@
   </section>
 
   <!-- 効果 -->
-  <section class="py-20 px-6 bg-white/70 dark:bg-base-200 ">
+  <section class="py-20 px-6 bg-white/70 dark:bg-base-100 ">
     <div class="max-w-4xl mx-auto">
       <h2 class="text-3xl font-mplus font-bold text-center mb-16 text-primary">
         ひだまり日記の効果
@@ -177,7 +177,7 @@
   </section>
 
   <!-- 再度促し -->
-  <section class="py-24 px-6 bg-base-100 dark:bg-base-200">
+  <section class="py-24 px-6">
     <div class="max-w-3xl mx-auto">
       <h2 class="text-lg mb-6 text-center">
         今日の小さな幸せを、今すぐ記録してみませんか？

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full min-h-screen bg-base-100 flex flex-col items-center justify-center overflow-hidden">
+<div class="w-full min-h-screen bg-base-100 dark:bg-base-200 flex flex-col items-center justify-center overflow-hidden">
 
   <!-- タイトル・サブタイトル-->
   <div class="text-center px-6">
@@ -16,7 +16,7 @@
       ひだまり日記は、日常の幸せや、自分の頑張りを記録し、振り返ることができる日記アプリです。
     </p>
     <div class="mt-6 flex flex-col justify-center gap-4">
-      <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white lg:py-6" %>
+      <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white dark:text-primary-content lg:py-6" %>
       <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-primary font-bold lg:py-6" %>
     </div>
   </div>
@@ -29,13 +29,13 @@
 </div>
 
 <!-- 特徴 -->
-  <section id="features" class="py-20 px-6 bg-white/70">
+  <section id="features" class="py-20 px-6 bg-white/70 dark:bg-base-200">
     <h2 class="font-mplus text-3xl font-bold text-center mb-12 text-primary">
       ひだまり日記の6つの特徴
     </h2>
 
     <div class="max-w-4xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10 justify-items-center">
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">edit_square</span>
         <h3 class="text-lg font-bold text-primary">気軽に記録できる</h3>
           <p class="text-sm">
@@ -43,7 +43,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">heart_plus</span>
         <h3 class="text-lg font-bold text-primary">あたたかいコミュニティ</h3>
           <p class="text-sml">
@@ -51,7 +51,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">alarm_on</span>
         <h3 class="text-lg font-bold text-primary">リマインド通知で習慣化</h3>
           <p class="text-sm">
@@ -59,7 +59,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">celebration</span>
         <h3 class="text-lg font-bold text-primary">幸せの可視化</h3>
           <p class="text-sm">
@@ -67,7 +67,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">lock_open</span>
         <h3 class="text-lg font-bold text-primary">公開・非公開の選択</h3>
           <p class="text-sm">
@@ -75,7 +75,7 @@
           </p>
       </div>
       
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">sell</span>
         <h3 class="text-lg font-bold text-primary">タグ付けと過去の検索</h3>
           <p class="text-sm">
@@ -86,7 +86,7 @@
   </section>
 
   <!-- 投稿例 -->
-  <section class="py-20 px-6">
+  <section class="py-20 px-6 dark:bg-base-200">
     <div class="max-w-4xl mx-auto">
       <h2 class="font-mplus text-3xl font-bold text-center mb-8 text-primary">
         日記の投稿例
@@ -96,7 +96,7 @@
       </p>
 
       <div class="space-y-6">
-        <div class="p-5 rounded-2xl shadow-xl bg-white border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
+        <div class="p-5 rounded-2xl shadow-xl bg-white dark:bg-base-100 border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
           <div class="flex items-center space-x-3 mb-2">
             <span class="material-symbols-outlined text-2xl text-accent">account_circle</span>
             <p class="font-bold">キリト</p>
@@ -106,7 +106,7 @@
           </p>
         </div>
 
-        <div class="p-5 rounded-2xl shadow-xl bg-white border-l-8 border-primary transition transform hover:shadow-2xl duration-300">
+        <div class="p-5 rounded-2xl shadow-xl bg-white dark:bg-base-100 border-l-8 border-primary transition transform hover:shadow-2xl duration-300">
           <div class="flex items-center space-x-3 mb-2">
             <span class="material-symbols-outlined text-2xl text-primary">account_circle</span>
             <p class="font-bold">アスナ</p>
@@ -116,7 +116,7 @@
           </p>
         </div>
 
-        <div class="p-5 rounded-2xl shadow-xl bg-white border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
+        <div class="p-5 rounded-2xl shadow-xl bg-white dark:bg-base-100 border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
           <div class="flex items-center space-x-3 mb-2">
             <span class="material-symbols-outlined text-2xl text-accent">account_circle</span>
             <p class="font-bold">ユイ</p>
@@ -130,14 +130,14 @@
   </section>
 
   <!-- 効果 -->
-  <section class="py-20 px-6 bg-white/70">
+  <section class="py-20 px-6 bg-white/70 dark:bg-base-200 ">
     <div class="max-w-4xl mx-auto">
       <h2 class="text-3xl font-mplus font-bold text-center mb-16 text-primary">
         ひだまり日記の効果
       </h2>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-        <div class="card flex flex-col items-center text-center p-8 bg-white border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
+        <div class="card flex flex-col items-center text-center p-8 bg-white dark:bg-base-100 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
           <div class="w-20 h-20 rounded-full bg-primary/20 flex items-center justify-center mb-4 shadow-inner">
             <span class="material-symbols-outlined text-5xl text-primary">
               volunteer_activism
@@ -149,7 +149,7 @@
           </p>
         </div>
 
-        <div class="card flex flex-col items-center text-center p-8 bg-white border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
+        <div class="card flex flex-col items-center text-center p-8 bg-white dark:bg-base-100 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
           <div class="w-20 h-20 rounded-full bg-primary/20 flex items-center justify-center mb-4 shadow-inner">
             <span class="material-symbols-outlined text-5xl text-primary">
               wb_sunny
@@ -161,7 +161,7 @@
           </p>
         </div>
 
-        <div class="card flex flex-col items-center text-center p-8 bg-white border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
+        <div class="card flex flex-col items-center text-center p-8 bg-white dark:bg-base-100 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
           <div class="w-20 h-20 rounded-full bg-primary/20 flex items-center justify-center mb-4 shadow-inner">
             <span class="material-symbols-outlined text-5xl text-primary">
               self_improvement
@@ -177,12 +177,14 @@
   </section>
 
   <!-- 再度促し -->
-  <section class="max-w-3xl mx-auto py-24 px-6 bg-base-100">
-    <h2 class="text-lg mb-6 text-center">
-      今日の小さな幸せを、今すぐ記録してみませんか？
-    </h2>
-    <div class="mt-6 flex flex-col justify-center gap-4">
-      <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white lg:py-6" %>
-      <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-primary font-bold lg:py-6" %>
+  <section class="py-24 px-6 bg-base-100 dark:bg-base-200">
+    <div class="max-w-3xl mx-auto">
+      <h2 class="text-lg mb-6 text-center">
+        今日の小さな幸せを、今すぐ記録してみませんか？
+      </h2>
+      <div class="mt-6 flex flex-col justify-center gap-4">
+        <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white dark:text-primary-content lg:py-6" %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-primary font-bold lg:py-6" %>
+      </div>
     </div>
   </section>

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -16,7 +16,7 @@
       ひだまり日記は、日常の幸せや、自分の頑張りを記録し、振り返ることができる日記アプリです。
     </p>
     <div class="mt-6 flex flex-col justify-center gap-4">
-      <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white dark:text-primary-content lg:py-6" %>
+      <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white lg:py-6" %>
       <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-primary font-bold lg:py-6" %>
     </div>
   </div>
@@ -29,13 +29,13 @@
 </div>
 
 <!-- 特徴 -->
-  <section id="features" class="py-20 px-6 bg-white/70 dark:bg-base-100">
+  <section id="features" class="py-20 px-6 dark:bg-base-100">
     <h2 class="font-mplus text-3xl font-bold text-center mb-12 text-primary">
       ひだまり日記の6つの特徴
     </h2>
 
     <div class="max-w-4xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10 justify-items-center">
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-base-200 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">edit_square</span>
         <h3 class="text-lg font-bold text-primary">気軽に記録できる</h3>
           <p class="text-sm">
@@ -43,7 +43,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-base-200 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">heart_plus</span>
         <h3 class="text-lg font-bold text-primary">あたたかいコミュニティ</h3>
           <p class="text-sml">
@@ -51,7 +51,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-base-200 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">alarm_on</span>
         <h3 class="text-lg font-bold text-primary">リマインド通知で習慣化</h3>
           <p class="text-sm">
@@ -59,7 +59,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-base-200 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">celebration</span>
         <h3 class="text-lg font-bold text-primary">幸せの可視化</h3>
           <p class="text-sm">
@@ -67,7 +67,7 @@
           </p>
       </div>
 
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-base-200 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">lock_open</span>
         <h3 class="text-lg font-bold text-primary">公開・非公開の選択</h3>
           <p class="text-sm">
@@ -75,7 +75,7 @@
           </p>
       </div>
       
-      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-white dark:bg-base-100 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
+      <div class="flex flex-col items-center text-center space-y-3 w-64 h-64 rounded-full bg-base-200 shadow-xl p-6 transition hover:-translate-y-1 hover:shadow-2xl duration-300 border-2 border-accent/50">
         <span class="material-symbols-outlined text-5xl text-primary">sell</span>
         <h3 class="text-lg font-bold text-primary">タグ付けと過去の検索</h3>
           <p class="text-sm">
@@ -96,7 +96,7 @@
       </p>
 
       <div class="space-y-6">
-        <div class="p-5 rounded-2xl shadow-xl bg-white dark:bg-base-100 border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
+        <div class="p-5 rounded-2xl shadow-xl bg-base-200 border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
           <div class="flex items-center space-x-3 mb-2">
             <span class="material-symbols-outlined text-2xl text-accent">account_circle</span>
             <p class="font-bold">キリト</p>
@@ -106,7 +106,7 @@
           </p>
         </div>
 
-        <div class="p-5 rounded-2xl shadow-xl bg-white dark:bg-base-100 border-l-8 border-primary transition transform hover:shadow-2xl duration-300">
+        <div class="p-5 rounded-2xl shadow-xl bg-base-200 border-l-8 border-primary transition transform hover:shadow-2xl duration-300">
           <div class="flex items-center space-x-3 mb-2">
             <span class="material-symbols-outlined text-2xl text-primary">account_circle</span>
             <p class="font-bold">アスナ</p>
@@ -116,7 +116,7 @@
           </p>
         </div>
 
-        <div class="p-5 rounded-2xl shadow-xl bg-white dark:bg-base-100 border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
+        <div class="p-5 rounded-2xl shadow-xl bg-base-200 border-l-8 border-accent transition transform hover:shadow-2xl duration-300">
           <div class="flex items-center space-x-3 mb-2">
             <span class="material-symbols-outlined text-2xl text-accent">account_circle</span>
             <p class="font-bold">ユイ</p>
@@ -130,14 +130,14 @@
   </section>
 
   <!-- 効果 -->
-  <section class="py-20 px-6 bg-white/70 dark:bg-base-100 ">
+  <section class="py-20 px-6 bg-base-100 ">
     <div class="max-w-4xl mx-auto">
       <h2 class="text-3xl font-mplus font-bold text-center mb-16 text-primary">
         ひだまり日記の効果
       </h2>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-        <div class="card flex flex-col items-center text-center p-8 bg-white dark:bg-base-100 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
+        <div class="card flex flex-col items-center text-center p-8 bg-base-200 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
           <div class="w-20 h-20 rounded-full bg-primary/20 flex items-center justify-center mb-4 shadow-inner">
             <span class="material-symbols-outlined text-5xl text-primary">
               volunteer_activism
@@ -149,7 +149,7 @@
           </p>
         </div>
 
-        <div class="card flex flex-col items-center text-center p-8 bg-white dark:bg-base-100 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
+        <div class="card flex flex-col items-center text-center p-8 bg-base-200 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
           <div class="w-20 h-20 rounded-full bg-primary/20 flex items-center justify-center mb-4 shadow-inner">
             <span class="material-symbols-outlined text-5xl text-primary">
               wb_sunny
@@ -161,7 +161,7 @@
           </p>
         </div>
 
-        <div class="card flex flex-col items-center text-center p-8 bg-white dark:bg-base-100 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
+        <div class="card flex flex-col items-center text-center p-8 bg-base-200 border-2 border-accent/50 rounded-3xl shadow-xl transition transform hover:-translate-y-1 hover:shadow-2xl duration-300">
           <div class="w-20 h-20 rounded-full bg-primary/20 flex items-center justify-center mb-4 shadow-inner">
             <span class="material-symbols-outlined text-5xl text-primary">
               self_improvement

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -16,7 +16,7 @@
       ひだまり日記は、日常の幸せや、自分の頑張りを記録し、振り返ることができる日記アプリです。
     </p>
     <div class="mt-6 flex flex-col justify-center gap-4">
-      <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white lg:py-6" %>
+      <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-secondary-content lg:py-6" %>
       <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-primary font-bold lg:py-6" %>
     </div>
   </div>
@@ -24,7 +24,7 @@
 
 <div class="absolute bottom-10 left-1/2 transform -translate-x-1/2">
   <a href=#features class="btn btn-circle btn-primary animate-bounce">
-    <span class="material-symbols-outlined text-2xl text-white">keyboard_double_arrow_down</span>
+    <span class="material-symbols-outlined text-2xl text-secondary-content">keyboard_double_arrow_down</span>
   </a>
 </div>
 
@@ -183,7 +183,7 @@
         今日の小さな幸せを、今すぐ記録してみませんか？
       </h2>
       <div class="mt-6 flex flex-col justify-center gap-4">
-        <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-white dark:text-primary-content lg:py-6" %>
+        <%= link_to "はじめる(無料)", new_user_registration_path, class: "btn btn-primary font-bold text-secondary-content lg:py-6" %>
         <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-primary font-bold lg:py-6" %>
       </div>
     </div>

--- a/app/views/shared/_fab_button.html.erb
+++ b/app/views/shared/_fab_button.html.erb
@@ -1,6 +1,6 @@
 <div class="fixed bottom-20 right-4 z-40 transition-transform duration-300 ease-in-out transform translate-y-0 md:right-1/7" data-controller="fab-button">
   <%= link_to new_diary_path, class: "btn btn-primary btn-circle w-14 h-14 shadow-lg" do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-secondary-content" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
     </svg>
   <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="fixed bottom-0 left-0 z-50 w-full h-16 backdrop-blur-md  bg-[#F9F9F9]/70 border-t border-gray-200">
+<footer class="fixed bottom-0 left-0 z-50 w-full h-16 backdrop-blur-md  bg-base-200/70 border-t border-gray-200">
   <div class="flex h-full w-full mx-auto justify-around items-center lg:px-20">
     <%= link_to home_path, class: "flex flex-col items-center" do %>
       <i class="fa-solid fa-house text-2xl md:text-3xl <%= highlight_class(home_path) %>"></i>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,36 +4,28 @@
     <%= link_to t('.site_name'), home_path, class: "font-mplus font-bold text-primary md:ml-2 text-md sm:text-lg lg:text-xl" %>
   </div>
 
-  <div class="flex items-center space-x-4">
-    <label class="flex cursor-pointer gap-2">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="20"
-        height="20"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round">
-        <circle cx="12" cy="12" r="5" />
-        <path
-          d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
-      </svg>
-      <input type="checkbox" value="sunset" class="toggle theme-controller" />
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="20"
-        height="20"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round">
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-      </svg>
-    </label>
+  <div class="flex items-center space-x-4" >
+    <div data-controller="theme"
+        data-theme-light-value="hidamarinikki"
+        data-theme-dark-value="sunset">
+
+      <label class="flex cursor-pointer gap-2">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5" />
+          <path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
+        </svg>
+
+        <input type="checkbox" 
+              value="sunset" 
+              class="toggle theme-controller" 
+              data-action="change->theme#toggle"
+              data-theme-target="toggle" />
+
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+      </label>
+    </div>
 
     <div class="drawer drawer-end">
         <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,37 @@
     <%= link_to t('.site_name'), home_path, class: "font-mplus font-bold text-primary md:ml-2 text-md sm:text-lg lg:text-xl" %>
   </div>
 
-  <div>
+  <div class="flex items-center space-x-4">
+    <label class="flex cursor-pointer gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5" />
+        <path
+          d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
+      </svg>
+      <input type="checkbox" value="sunset" class="toggle theme-controller" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      </svg>
+    </label>
+
     <div class="drawer drawer-end">
         <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
         <div class="drawer-content">
@@ -13,7 +43,7 @@
             <svg class="swap-off fill-current text-neutral" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512"><path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z" /></svg>
             <svg class="swap-on fill-current text-neutral" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512"><polygon points="400 145.49 366.51 112 256 222.51 145.49 112 112 145.49 222.51 256 112 366.51 145.49 400 256 289.49 366.51 400 400 366.51 289.49 256 400 145.49" /></svg>
         </label>
-        </div> 
+        </div>
         <div class="drawer-side z-50">
         <label for="my-drawer-4" aria-label="close sidebar" class="drawer-overlay"></label>
         <ul class="menu p-4 w-80 min-h-full bg-base-200 text-base-content">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -30,10 +30,10 @@
     <div class="drawer drawer-end">
         <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
         <div class="drawer-content">
-        <label for="my-drawer-4" class="btn btn-circle swap swap-rotate btn-neutral btn-ghost">
+        <label for="my-drawer-4" class="btn btn-circle swap swap-rotate btn-primary btn-ghost">
             <input type="checkbox" />
-            <svg class="swap-off fill-current text-neutral" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512"><path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z" /></svg>
-            <svg class="swap-on fill-current text-neutral" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512"><polygon points="400 145.49 366.51 112 256 222.51 145.49 112 112 145.49 222.51 256 112 366.51 145.49 400 256 289.49 366.51 400 400 366.51 289.49 256 400 145.49" /></svg>
+            <svg class="swap-off fill-current" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512"><path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z" /></svg>
+            <svg class="swap-on fill-current" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512"><polygon points="400 145.49 366.51 112 256 222.51 145.49 112 112 145.49 222.51 256 112 366.51 145.49 400 256 289.49 366.51 400 400 366.51 289.49 256 400 145.49" /></svg>
         </label>
         </div>
         <div class="drawer-side z-50">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,7 +14,7 @@
   <div class="w-full mt-8">
     <h3 class="font-medium mb-2">ユーザー名</h3>
     <!-- `p`タグにも input クラスを適用 -->
-    <p class="input input-bordered w-full bg-white flex items-center h-12"><%= @user.name %></p>
+    <p class="input input-bordered w-full bg-base-200 flex items-center h-12"><%= @user.name %></p>
   </div>
 
   <!-- 自己紹介 -->
@@ -22,7 +22,7 @@
     <div class="w-full mt-8">
       <h3 class="font-medium mb-2">自己紹介</h3>
       <!-- `p`タグにも textarea クラスを適用 -->
-      <p class="textarea textarea-bordered textarea-profile w-full bg-white h-auto"><%= @user.introduction %></p>
+      <p class="textarea textarea-bordered textarea-profile w-full bg-base-200 h-auto"><%= @user.introduction %></p>
     </div>
   <% end %>
 


### PR DESCRIPTION
## 実装内容の概要
- 新しいカスタムテーマ `sunset `を追加し、ライト/ダークモードの切り替えを実装しました。
- Stimulus を用いてテーマ選択をローカルストレージに保存し、ページ遷移やリロード後も選択したテーマを保持しています。
- 初回訪問時には OS のテーマ設定を優先して適用しています。
- 既存の bg-white など直接色指定していた箇所を`bg-base-200`に統一しました。
- 既存テーマ hidamarinikki の`base-200`と`secondary-content`を白系(#FDFBF7)に変更しました。。
- テキストカラーについて`text-white`を`text-secondary-content`に置き換え、テーマに応じて適切に変化するよう修正しました。

### TOPページ（ダークモード）
[![Image from Gyazo](https://i.gyazo.com/1c2722bfea4d8371a870dae6372b1db7.gif)](https://gyazo.com/1c2722bfea4d8371a870dae6372b1db7)

### ログイン後、テーマの切り替え・ページ遷移してもテーマが保持されている
[![Image from Gyazo](https://i.gyazo.com/8b737472e0cb918628ff9460ca0dde25.gif)](https://gyazo.com/8b737472e0cb918628ff9460ca0dde25)

### ひだまり日記書き方ガイド（ダークモード）
[![Image from Gyazo](https://i.gyazo.com/d3be26ffff603e1eb6ca318388f5838c.gif)](https://gyazo.com/d3be26ffff603e1eb6ca318388f5838c)

### 設定モーダル・ユーザー詳細・編集画面（ダークモード）
[![Image from Gyazo](https://i.gyazo.com/d8cb77252a51aeeb87222cbceef6b824.gif)](https://gyazo.com/d8cb77252a51aeeb87222cbceef6b824)
## 技術的な詳細
**テーマ追加**
- daisyUI の @plugin "daisyui/theme" を利用し、sunset テーマを新規追加しました。
- color-scheme: "dark" を指定し、ダークモード用のカラーパレットを定義しました。

**Stimulus**
- `app/javascript/controllers/theme_controller.js`を作成し、テーマの切り替えを制御しています。
- 選択したテーマを localStorage に保存しています。connect() 時に保存済みテーマを復元し、未保存の場合はOSのテーマカラーを適応します。 

**既存テーマの調整**
- daisyUI のテーマ切り替えは「data-theme によるテーマ変数」専用で、TailwindCSSによる`dark:` と daisyUI のテーマは連動しない為、以下のように直接色を指定するのではなくdaisyUIのテーマ変数に変更しました。
- hidamarinikki テーマの --color-base-200 を白系(#FDFBF7)に変更しました。従来bg-whiteを使っていた箇所を置き換えました。
- secondary-content を白系(#FDFBF7)に変更し、従来 text-white を使っていた箇所を置き換えました。


## 確認事項
- [x] TOPページがダークモードに対応しているかどうか
- [x] 新規登録画面・ログイン画面がダークモードに対応しているかどうか
- [x] ログイン後のそれぞれの画面がダークモードに対応しているかどうか
- [x] 日記投稿・ユーザー編集などのフォーム入力画面がダークモードに対応しているかどうか 
- [x] OS側でダークモードに設定しているときにページを訪れると、ダークモードになっており、トグルもダークモード側になっているかどうか

## 関連Issue
Close #101 