### PR TITLE
フォームの必須項目に*マークを追加

### DIFF
--- a/app/javascript/controllers/status_selector_controller.js
+++ b/app/javascript/controllers/status_selector_controller.js
@@ -8,13 +8,13 @@ export default class extends Controller {
     if (!clickedDiv) return;
 
     this.element.querySelectorAll('div[data-action]').forEach(div => {
-      div.querySelector('button').classList.remove('btn-secondary', 'btn-active');
+      div.querySelector('button').classList.remove('btn-accent', 'btn-active');
       div.querySelector('button').classList.add('btn-outline');
     });
 
     const clickedButton = clickedDiv.querySelector('button');
     if (clickedButton) {
-      clickedButton.classList.add('btn-secondary', 'btn-active');
+      clickedButton.classList.add('btn-accent', 'btn-active');
       clickedButton.classList.remove('btn-outline');
 
       const selectedValue = clickedDiv.dataset.value;

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -29,7 +29,7 @@
 
     <div class="w-full mt-8">
       <%= f.label :introduction, class: "font-medium mb-2" %>
-      <%= f.text_area :introduction, placeholder: "200文字まで", class: "textarea textarea-bordered textarea-profile bg-200 lg:w-[1024px]" %>
+      <%= f.text_area :introduction, placeholder: "200文字まで", class: "textarea textarea-bordered textarea-profile bg-base-200 lg:w-[1024px]" %>
     </div>
 
     <div class="w-full mt-8">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,6 +23,7 @@
     <!-- ユーザー名 -->
     <div class="w-full mt-8">
       <%= f.label :name, class: "font-medium mb-2" %>
+      <span class="text-red-500">*</span>
       <%= f.text_field :name, class: "input input-bordered bg-base-200 w-full" %>
     </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,7 +16,7 @@
         <%= avatar_placeholder(resource) %>
       <% end %>
 
-      <%= f.file_field :avatar, class: "file-input" %>
+      <%= f.file_field :avatar, class: "file-input file-input-neutral" %>
     </div>
 
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,6 +9,7 @@
       <div class="form-control w-full max-w-md">
         <label class="label">
           <span class="label-text font-semibold"><%= t('devise.shared.name') %></span>
+          <span class="text-red-500">*</span>
         </label>
         <%= f.text_field :name, placeholder: t('devise.shared.placeholders.name'), class: "input input-primary w-full" %>
       </div>
@@ -17,6 +18,7 @@
       <div class="form-control w-full max-w-md">
         <label class="label">
           <span class="label-text font-semibold"><%= t('devise.shared.email') %></span>
+          <span class="text-red-500">*</span>
         </label>
         <%= f.email_field :email, placeholder: t('devise.shared.placeholders.email'), class: "input input-primary w-full" %>
       </div>
@@ -28,6 +30,7 @@
         </label>
         <% if @minimum_password_length %>
           <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+          <span class="text-red-500">*</span>
         <% end %>
 
         <div class="input-group relative">
@@ -65,6 +68,7 @@
       <div class="form-control w-full max-w-md" data-controller="password-visibility">
         <label class="label">
           <span class="label-text font-semibold"><%= t('devise.shared.password_confirmation') %></span>
+          <span class="text-red-500">*</span>
         </label>
 
         <div class="input-group relative">

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -89,7 +89,7 @@
 
       <div class="w-full flex justify-center mt-4">
         <%= f.file_field :photos, 
-                        class: "file-input file-input-secondary", 
+                        class: "file-input file-input-accent", 
                         multiple: true,
                         accept: "image/*",
                         data: {
@@ -101,11 +101,11 @@
       <!-- 公開・非公開ボタン -->
       <div data-controller="status-selector" class="flex items-center space-x-4 mt-8">
         <div data-action="click->status-selector#select" data-value="is_public">
-          <button type="button" data-status-selector-target="button" class="btn btn-outline <%= @diary_form.status == 'is_public' ? 'btn-active btn-secondary' : '' %>">公開</button>
+          <button type="button" data-status-selector-target="button" class="btn btn-outline <%= @diary_form.status == 'is_public' ? 'btn-active btn-accent' : '' %>">公開</button>
           <%= f.radio_button :status, :is_public, class: "hidden", checked: @diary_form.status == 'is_public' %>
         </div>
         <div data-action="click->status-selector#select" data-value="is_private">
-          <button type="button" data-status-selector-target="button" class="btn btn-outline <%= @diary_form.status == 'is_private' ? 'btn-active btn-secondary' : '' %>">非公開</button>
+          <button type="button" data-status-selector-target="button" class="btn btn-outline <%= @diary_form.status == 'is_private' ? 'btn-active btn-accent' : '' %>">非公開</button>
           <%= f.radio_button :status, :is_private, class: "hidden", checked: @diary_form.status == 'is_private' %>
         </div>
       </div>

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -28,7 +28,10 @@
         <% @diary_form.happiness_items.each_with_index do |item, i| %>
           <div class="form-control relative">
             <div class="label">
-              <span class="label-text"><%= i + 1 %></span>
+                <span class="label-text">
+                  <%= i + 1 %><% if i == 0 %><span class="text-red-500 ml-1">*</span><% end %>
+                </span>
+
               <% if i > 0 %> <!-- 最初の項目は削除不可 -->
                 <button type="button" class="btn btn-xs btn-circle btn-ghost absolute top-0 right-0" data-action="diary#removeItem">
                   ✕

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -23,6 +23,7 @@
       <div class="form-control">
         <label class="label">
           <span class="label-text font-semibold mt-8 mb-2">利用シーン</span>
+          <span class="text-red-500">*</span>
         </label>
         <p class="text-sm mb-6">
           日常のルーティンに合わせて通知を設定しましょう。
@@ -40,6 +41,7 @@
             <div class="form-control">
               <label class="label">
                 <span class="label-text">シーン</span>
+                <span class="text-red-500">*</span>
               </label>
               <%= f.select :scene_name, [
                 ["朝のスタート", "morning"],
@@ -63,6 +65,7 @@
             <div class="form-control">
               <label class="label">
                 <span class="label-text">シーン名</span>
+                <span class="text-red-500">*</span>
               </label>
               <%= f.text_field :scene_name, class: "input input-bordered w-full max-w-xs",
               data: { "scene-target" => "customText" } %>
@@ -73,6 +76,7 @@
         <div class="form-control mt-10" data-controller="notification-time">
           <label class="label">
             <span class="label-text font-semibold">通知時間</span>
+            <span class="text-red-500">*</span>
           </label>
           <p class="text-sm mt-1">※選択した時間は15分単位に調整されます。</p>
           <%= f.time_field :notification_time, class: "input input-bordered w-full max-w-xs mt-4", data: { notification_time_target: "input" } %>


### PR DESCRIPTION
## 実装内容の概要
以下のページのフォームの必須項目に赤い*マークを追加しました。
### 新規登録ページ
<img width="1915" height="907" alt="スクリーンショット 2025-10-05 130352" src="https://github.com/user-attachments/assets/b967f735-2418-4a8b-8034-b4888c65b705" />

### 日記投稿・編集フォーム
<img width="1919" height="909" alt="スクリーンショット 2025-10-05 130507" src="https://github.com/user-attachments/assets/a56fd758-639c-4c47-974c-56f9e66cb7af" />

### ユーザー編集フォーム
<img width="1919" height="909" alt="スクリーンショット 2025-10-05 130534" src="https://github.com/user-attachments/assets/2f6ee84a-1e6e-49d7-a694-656ee08b5c2c" />

### 通知設定画面
OnSignalの設定URLを本番環境のURLに変更し、ローカル環境では通知をONに切り替えができない為、確認不可。

### その他修正
-ユーザー編集画面の画像ファイルの選択フィールドの色をneutralに変更しました。
理由:以前base-200の色を変更したことが原因で、設定した色と違う色になっていた為。
- 日記投稿・編集画面の、画像ファイルの選択フィールドと、公開ステータスの色をaccentに変更しました。
理由:日記フォームに様々な色が混在していたため、フォームはaccentに統一しました。

## 関連Issue
Close #121 