### PR TITLE
ユーザー新規登録に関するシステムスペックを追加

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,29 +7,25 @@
 
       <!-- 名前 -->
       <div class="form-control w-full max-w-md">
-        <label class="label">
-          <span class="label-text font-semibold"><%= t('devise.shared.name') %></span>
+        <%= f.label :name, t('devise.shared.name'), class: "label-text font-semibold" %>
           <span class="text-red-500">*</span>
-        </label>
         <%= f.text_field :name, placeholder: t('devise.shared.placeholders.name'), class: "input input-primary w-full" %>
       </div>
 
       <!-- メールアドレス -->
       <div class="form-control w-full max-w-md">
-        <label class="label">
-          <span class="label-text font-semibold"><%= t('devise.shared.email') %></span>
+        <%= f.label :email, t('devise.shared.email'), class: "label-text font-semibold" %>
           <span class="text-red-500">*</span>
-        </label>
         <%= f.email_field :email, placeholder: t('devise.shared.placeholders.email'), class: "input input-primary w-full" %>
       </div>
 
       <!-- パスワード -->
       <div class="form-control w-full max-w-md" data-controller="password-visibility">
-        <label class="label">
-          <span class="label-text font-semibold"><%= t('devise.shared.password') %></span>
-        </label>
+        <%= f.label :password, t('devise.shared.password'), class: "label-text font-semibold" %>
         <% if @minimum_password_length %>
-          <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+          <em class="font-semibold">
+            <%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %>
+          </em>
           <span class="text-red-500">*</span>
         <% end %>
 
@@ -66,10 +62,8 @@
 
       <!-- パスワード確認用 -->
       <div class="form-control w-full max-w-md" data-controller="password-visibility">
-        <label class="label">
-          <span class="label-text font-semibold"><%= t('devise.shared.password_confirmation') %></span>
+        <%= f.label :password_confirmation, t('devise.shared.password_confirmation'), class: "label-text font-semibold" %>
           <span class="text-red-500">*</span>
-        </label>
 
         <div class="input-group relative">
         <%= f.password_field :password_confirmation,

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -27,6 +27,5 @@ RSpec.describe "Users", type: :system do
         expect(page).to have_content 'メールアドレスを入力してください'
         expect(page).to have_content 'パスワードを入力してください'
       end
-
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  describe '新規登録' do
+    context '有効な入力した場合'
+      it '新規登録が成功すること' do
+        visit new_user_registration_path
+        fill_in 'ユーザー名', with: 'テストユーザー'
+        fill_in 'メールアドレス', with: 'test@example.com'
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード（確認用）', with: 'password'
+        click_button '登録'
+
+        expect(page).to have_content 'アカウント登録が完了しました'
+        expect(User.count).to eq(1)
+      end
+
+    context '必須項目が未入力の場合'
+      it 'エラーになり、新規登録が失敗すること' do
+        visit new_user_registration_path
+        fill_in 'ユーザー名', with: ''
+        fill_in 'メールアドレス', with: ''
+        fill_in 'パスワード', with: ''
+        click_button '登録'
+
+        expect(page).to have_content 'ユーザー名を入力してください'
+        expect(page).to have_content 'メールアドレスを入力してください'
+        expect(page).to have_content 'パスワードを入力してください'
+      end
+
+  end
+end


### PR DESCRIPTION
## 実装内容の概要
- ユーザー新規登録に関するシステムスペックを追加
- フォームのラベルを修正し、label と input が正しく紐づくように変更

## 技術的な詳細
### システムスペック
- `spec/system/users_spec.rb`を作成し、ユーザー新規登録のシステムスペックテストを追記
- `visit new_user_registration_path` からフォーム入力 →「アカウント登録が完了しました」が表示されることを確認
- 必須項目未入力時にエラーメッセージが表示されることを確認

### フォームラベルの修正
- テストを実行した際、`fill_in 'ユーザー名', with: 'テストユーザー'ユーザー名が見つからないというエラーが発生し、ラベルの記述を修正。これにより、ラベルと入力フィールドが正しく関連付けられ、テストコードでラベル名を使った fill_in が可能になりました。

## 関連Issue
Close #141 