### PR TITLE
カスタムドメインをホワイトリストに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    "hidamarinikki.jp",     # Allow requests from example.com
+    "www.hidamarinikki.jp"  # Allow requests from subdomains like `www.example.com`
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 実装内容の概要
- カスタムドメインをホワイトリストに追加

## 技術的な詳細
- `config/environments/production.rb`に取得したカスタムドメインを追加しました。
理由:　Railsは許可されていないドメインでのアクセスを拒否するため

## 関連Issue
Close 124
