### PR TITLE
feat: RenderのオリジナルURLを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,8 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
     "hidamarinikki.jp",     # Allow requests from example.com
-    "www.hidamarinikki.jp"  # Allow requests from subdomains like `www.example.com`
+    "www.hidamarinikki.jp",  # Allow requests from subdomains like `www.example.com`
+    "https://hidamarinikki-gdca.onrender.com"
   ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }


### PR DESCRIPTION
## 実装内容の概要
- 以前のカスタムドメインのURLを追加したら、RenderのオリジナルURLでのアクセスができなくなったため、そちらも追加
