### PR TITLE
Renderのドメインの登録を修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,7 +99,7 @@ Rails.application.configure do
   config.hosts = [
     "hidamarinikki.jp",     # Allow requests from example.com
     "www.hidamarinikki.jp",  # Allow requests from subdomains like `www.example.com`
-    "https://hidamarinikki-gdca.onrender.com"
+    "hidamarinikki-gdca.onrender.com"
   ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }


### PR DESCRIPTION
## 実装内容の概要
- 以前Renderのドメインの追加しましたが、https://を含んでおり間違っていた為、修正

