### PR TITLE
ホーム画面アクセス時に、瓶が満タンになっているかどうか判定

### DIFF
--- a/app/javascript/controllers/happiness_jar_controller.js
+++ b/app/javascript/controllers/happiness_jar_controller.js
@@ -129,6 +129,11 @@ export default class extends Controller {
     if (this.deletedIdsValue?.length > 0) {
       this.handleDecreaseAnimation(this.deletedIdsValue)
     }
+
+    // 瓶が満タンか再判定
+    if (this.happinessList.length >= this.capacity) {
+      this.onJarFull()
+    }
   }
 
   // IDを指定して追加処理を行う（共通化）


### PR DESCRIPTION
## 実装内容の概要
- ホーム画面にアクセスした際に、幸せ瓶が満タンになっているかどうかを再チェックするように実装
  
## 理由
以前、幸せ瓶の満タン基準を120→75にしましたが、既に75を超えている人は満タンになっているかどうかの判定ができておらず、幸せ瓶がいっぱいのままでした。
従来の、日記が追加された際に75を超えるとonJarFullが実行されるのは変わらず、追加でホームが画面接続時に再チェックを行い、より牢獄的にonJarFullを実施できるようにしました。
