### PR TITLE
オーバーフローの処理をonJarFullに追加

### DIFF
--- a/app/javascript/controllers/happiness_jar_controller.js
+++ b/app/javascript/controllers/happiness_jar_controller.js
@@ -322,6 +322,13 @@ export default class extends Controller {
     const modalToggle = document.getElementById("full-jar-modal")
     if (modalToggle) modalToggle.checked = true
 
+    if (this.happinessList.length > this.capacity) {
+      const overflow = this.happinessList.slice(this.capacity)
+      overflow.forEach(h => {
+        this.overflowQueue.push(h.itemIndex)
+      })
+    }
+
     // フォールバック: 15秒後に自動で新しい瓶へ
     this.autoReplaceTimer = setTimeout(() => {
       this.replaceWithNewBottle()


### PR DESCRIPTION
## 実装内容の概要
- 瓶がいっぱいになって溢れた分を次の瓶に入れる処理（オーバーフロー）をonJarFullに追加

## 理由
元々は、幸せを追加した際にcapacityを超えたものはオーバーフローに追加し、次の瓶でオーバーフローがあれば追加するという処理をしていました。
1つ前のPRでホーム画面にアクセスした際にonJarFullを確認すように実装し、その際は追加処理ではないので溢れた分は次の瓶に追加されない仕様になってました。
その為、ホーム画面にアクセスした際にonJarFullが実行された場合、75を超えた分は次の瓶に反映されるようにしました。