### PR TITLE
notification_settingsテーブルのuser_idにuniqueを追加

### DIFF
--- a/db/migrate/20251110130326_add_unique_index_to_notification_settings.rb
+++ b/db/migrate/20251110130326_add_unique_index_to_notification_settings.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToNotificationSettings < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :notification_settings, :user_id
+    add_index :notification_settings, :user_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_08_134607) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_10_130326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,7 +82,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_08_134607) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["notification_time"], name: "index_notification_settings_on_notification_time"
-    t.index ["user_id"], name: "index_notification_settings_on_user_id"
+    t.index ["user_id"], name: "index_notification_settings_on_user_id", unique: true
   end
 
   create_table "tags", force: :cascade do |t|


### PR DESCRIPTION
## 実装内容の概要
- Rails側（モデル）では`has_one :notification_setting`となっていましたが、DB側では複数の通知の設定ができるようになっていた為、DB側でもunique制限を追加
